### PR TITLE
Log OpenPGP errors instead of returning invalid values

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -147,8 +147,10 @@ class Controller(object):
             dev = self._descriptor.open_device(TRANSPORT.CCID)
             controller = OpgpController(dev.driver)
             controller.reset()
+            return True
         except Exception as e:
-            return str(e)
+            logger.error('Failed to reset OpenPGP applet', exc_info=e)
+            return False
 
     def openpgp_get_touch(self):
         try:
@@ -159,7 +161,8 @@ class Controller(object):
             sig = controller.get_touch(KEY_SLOT.SIGN)
             return [auth, enc, sig]
         except Exception as e:
-            return str(e)
+            logger.error('Failed to get OpenPGP touch policy', exc_info=e)
+            return None
 
     def openpgp_set_touch(self, admin_pin, auth, enc, sig):
         try:
@@ -174,8 +177,10 @@ class Controller(object):
             if sig >= 0:
                 controller.set_touch(
                     KEY_SLOT.SIGN, int(sig), admin_pin.encode())
+            return True
         except Exception as e:
-            return str(e)
+            logger.error('Failed to set OpenPGP touch policy', exc_info=e)
+            return False
 
     def openpgp_set_pin_retries(
             self, admin_pin, pin_retries, reset_code_retries,
@@ -186,8 +191,10 @@ class Controller(object):
             controller.set_pin_retries(
                 int(pin_retries), int(reset_code_retries),
                 int(admin_pin_retries), admin_pin.encode())
+            return True
         except Exception as e:
-            return str(e)
+            logger.error('Failed to set OpenPGP PIN retries', exc_info=e)
+            return False
 
     def openpgp_get_version(self):
         try:
@@ -195,7 +202,8 @@ class Controller(object):
             controller = OpgpController(dev.driver)
             return controller.version
         except Exception as e:
-            return str(e)
+            logger.error('Failed to get OpenPGP applet version', exc_info=e)
+            return None
 
     def openpgp_get_remaining_pin_retries(self):
         try:
@@ -203,7 +211,9 @@ class Controller(object):
             controller = OpgpController(dev.driver)
             return controller.get_remaining_pin_tries()
         except Exception as e:
-            return str(e)
+            logger.error('Failed to get remaining OpenPGP PIN retries',
+                         exc_info=e)
+            return None
 
 
 controller = Controller()


### PR DESCRIPTION
This was left behind and forgotten in the `menus-and-opgp-alt-fix` branch mentioned in #8.