### PR TITLE
Windows: allow resize and calculate correct height

### DIFF
--- a/ykman-gui/qml/DeviceInfo.qml
+++ b/ykman-gui/qml/DeviceInfo.qml
@@ -6,10 +6,9 @@ Item {
     property var device
     property int margin: Layout.minimumWidth / 30
 
-    width: 370
-    height: 350
     Layout.minimumWidth: 370
-    Layout.minimumHeight: 350
+    Layout.minimumHeight: deviceBox.implicitHeight + featureBox.implicitHeight
+                          + connectionsBox.implicitHeight + margin * 4
 
     ColumnLayout {
         anchors.fill: parent

--- a/ykman-gui/qml/main.qml
+++ b/ykman-gui/qml/main.qml
@@ -6,8 +6,6 @@ import QtQuick.Dialogs 1.2
 ApplicationWindow {
     visible: true
     title: qsTr("YubiKey Manager")
-    flags: Qt.CustomizeWindowHint | Qt.WindowTitleHint | Qt.WindowCloseButtonHint
-           | Qt.WindowMinimizeButtonHint | Qt.MSWindowsFixedSizeDialogHint
 
     menuBar: MainMenuBar {
         enabledFeatures: yk.enabled


### PR DESCRIPTION
Testing: make sure window is not to high or to low, and that resizing is enabled (mostly on Windows)