### PR TITLE
Refresh PIV data on demand instead of periodically

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -96,23 +96,23 @@ class Controller(object):
                     'piv': {},
                 }
 
-        with self._open_piv() as piv_controller:
-            if self._dev_info:
-                piv_certificates = self._piv_list_certificates(piv_controller)
-
-                self._dev_info['piv'] = {
-                    'version': '.'.join(
-                        str(x) for x in self._piv_version(piv_controller)),
-                    'certificates': piv_certificates,
-                    'has_protected_key': piv_controller.has_protected_key,
-                    'pin_tries': piv_controller.get_pin_tries(),
-                    'supported_touch_policies': [
-                        policy.name for policy in
-                        piv_controller.supported_touch_policies],
-                    'supports_pin_policies': piv_controller.supports_pin_policies,  # noqa: E501
-                }
-
         return self._dev_info
+
+    def refresh_piv(self):
+        with self._open_piv() as piv_controller:
+            piv_certificates = self._piv_list_certificates(piv_controller)
+
+            return {
+                'version': '.'.join(
+                    str(x) for x in self._piv_version(piv_controller)),
+                'certificates': piv_certificates,
+                'has_protected_key': piv_controller.has_protected_key,
+                'pin_tries': piv_controller.get_pin_tries(),
+                'supported_touch_policies': [
+                    policy.name for policy in
+                    piv_controller.supported_touch_policies],
+                'supports_pin_policies': piv_controller.supports_pin_policies,  # noqa: E501
+            }
 
     def set_mode(self, connections):
         logger.debug('connections: %s', connections)

--- a/ykman-gui/qml/PivManager.qml
+++ b/ykman-gui/qml/PivManager.qml
@@ -462,7 +462,7 @@ DefaultDialog {
     }
 
     function start() {
-        show()
+        device.refreshPiv(show)
     }
 
     function startChangePin() {


### PR DESCRIPTION
This stops `refresh()` from spewing that torrent of debug logging every half second.