### PR TITLE
Add dependency qml-module-qt-labs-folderlistmodel

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,7 @@ Depends: ${misc:Depends},
          python3-yubikey-manager (>= 0.6.0~dev),
          python3-yubikey-manager (< 0.7),
          qml-module-io-thp-pyotherside,
+         qml-module-qt-labs-folderlistmodel,
          qml-module-qtquick-controls,
          qml-module-qtquick-dialogs,
          pcscd


### PR DESCRIPTION
This fixes the missing module reported by @dainnilsson in 0.5.0-rc1. The package is availabe in both Xenial and Bionic.