### PR TITLE
 Exit the application on KeyboardInterrupt

### DIFF
--- a/ykman-cli/qml/main.qml
+++ b/ykman-cli/qml/main.qml
@@ -20,7 +20,7 @@ Python {
         })
     }
     function handleErrors(traceback) {
-        if (Utils.includes(traceback, 'KeyboardInterrupt')) {
+        if (traceback.indexOf('KeyboardInterrupt') >= 0) {
             Qt.quit()
         } else {
             console.log(traceback)

--- a/ykman-cli/qml/main.qml
+++ b/ykman-cli/qml/main.qml
@@ -1,10 +1,11 @@
 import QtQml 2.2
 import io.thp.pyotherside 1.4
 
+
+// @disable-check M300
 Python {
-    onError: {
-        console.log('Python error: ' + traceback)
-    }
+
+    onError: handleErrors(traceback)
 
     Component.onCompleted: {
         importModule('site', function () {
@@ -17,5 +18,12 @@ Python {
                 })
             })
         })
+    }
+    function handleErrors(traceback) {
+        if (Utils.includes(traceback, 'KeyboardInterrupt')) {
+            Qt.quit()
+        } else {
+            console.log(traceback)
+        }
     }
 }

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -51,6 +51,16 @@ Python {
     onYubikeyModuleLoadedChanged: runQueue()
     onYubikeyReadyChanged: runQueue()
 
+    onError: handleErrors(traceback)
+
+    function handleErrors(traceback) {
+        if (Utils.includes(traceback, 'KeyboardInterrupt')) {
+            Qt.quit()
+        } else {
+            console.log(traceback)
+        }
+    }
+
     function isPythonReady(funcName) {
         if (Utils.startsWith(funcName, "yubikey.init")) {
             return yubikeyModuleLoaded

--- a/ykman-gui/qml/main.qml
+++ b/ykman-gui/qml/main.qml
@@ -71,7 +71,7 @@ ApplicationWindow {
     // @disable-check M301
     YubiKey {
         id: yk
-        onError: console.log(traceback)
+
         onHasDeviceChanged: mainStack.update()
     }
 


### PR DESCRIPTION
Should create cleaner exits from Qt-wrapped CLI
binary, as well as allowing starting and exiting
the GUI from the terminal.