### PR TITLE
Sort qrc input file list

### DIFF
--- a/build_qrc.py
+++ b/build_qrc.py
@@ -18,6 +18,8 @@ def build_qrc(resources):
     yield '<qresource>'
     for d in resources:
         for root, dirs, files in os.walk(d):
+            dirs.sort()
+            files.sort()
             for f in files:
                 yield '<file>{}</file>'.format(os.path.join(root, f))
     yield '</qresource>'


### PR DESCRIPTION
so that yubikey-manager-qt packages build in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

Same as https://github.com/Yubico/yubioath-desktop/pull/278