### PR TITLE
Restructure navigation

### DIFF
--- a/ykman-gui/qml/BreadCrumb.qml
+++ b/ykman-gui/qml/BreadCrumb.qml
@@ -4,8 +4,8 @@ import QtQuick.Controls 2.2
 Label {
     property bool active
     property var action
-    color: active ? yubicoGrey : yubicoGreen
-    font.underline: !active && mouseArea.containsMouse
+    color: action ? yubicoGreen : yubicoGrey
+    font.underline: !active && action && mouseArea.containsMouse
     font.pixelSize: constants.h4
 
     MouseArea {

--- a/ykman-gui/qml/BreadCrumbRow.qml
+++ b/ykman-gui/qml/BreadCrumbRow.qml
@@ -8,7 +8,7 @@ RowLayout {
 
     BreadCrumb {
         text: root.text
-        action: items.length > 0 && function() { popToHeight(0) }
+        action: items.length > 0 && function() { popToDepth(0) }
     }
 
     Repeater {
@@ -20,7 +20,7 @@ RowLayout {
             BreadCrumb {
                 text: items[index].text
                 action: !active && function() {
-                    popToHeight(index + 1)
+                    popToDepth(index + 1)
                 }
                 active: index === items.length - 1
             }

--- a/ykman-gui/qml/BreadCrumbRow.qml
+++ b/ykman-gui/qml/BreadCrumbRow.qml
@@ -4,11 +4,15 @@ import QtQuick.Layouts 1.2
 RowLayout {
 
     property var items
-    property var root: ({ text: qsTr("Home") })
+    property var root: ({
+                            text: qsTr("Home")
+                        })
 
     BreadCrumb {
         text: root.text
-        action: items.length > 0 && function() { popToDepth(0) }
+        action: items.length > 0 && function () {
+            popToDepth(0)
+        }
     }
 
     Repeater {
@@ -19,7 +23,7 @@ RowLayout {
             }
             BreadCrumb {
                 text: items[index].text
-                action: !active && function() {
+                action: !active && function () {
                     popToDepth(index + 1)
                 }
                 active: index === items.length - 1

--- a/ykman-gui/qml/BreadCrumbRow.qml
+++ b/ykman-gui/qml/BreadCrumbRow.qml
@@ -10,9 +10,9 @@ RowLayout {
 
     BreadCrumb {
         text: root.text
-        action: items.length > 0 && function () {
+        action: root.action || (items.length > 0 && function () {
             popToDepth(0)
-        }
+        })
     }
 
     Repeater {
@@ -23,10 +23,11 @@ RowLayout {
             }
             BreadCrumb {
                 text: items[index].text
-                action: !active && function () {
-                    popToDepth(index + 1)
-                }
-                active: index === items.length - 1
+                action: items[index].action || (index < items.length - 1
+                                                && function () {
+                                                    popToDepth(index + 1)
+                                                })
+                active: !!action
             }
         }
     }

--- a/ykman-gui/qml/BreadCrumbRow.qml
+++ b/ykman-gui/qml/BreadCrumbRow.qml
@@ -2,4 +2,29 @@ import QtQuick 2.9
 import QtQuick.Layouts 1.2
 
 RowLayout {
+
+    property var items
+    property var root: ({
+                            text: qsTr("Home"),
+                            action: views.home
+                        })
+
+    BreadCrumb {
+        text: root.text
+        action: root.action
+    }
+
+    Repeater {
+        model: items
+
+        RowLayout {
+            BreadCrumbSeparator {
+            }
+            BreadCrumb {
+                text: items[index].text
+                action: items[index].action
+                active: index == items.length - 1
+            }
+        }
+    }
 }

--- a/ykman-gui/qml/BreadCrumbRow.qml
+++ b/ykman-gui/qml/BreadCrumbRow.qml
@@ -3,7 +3,25 @@ import QtQuick.Layouts 1.2
 
 RowLayout {
 
+
+    /**
+     * Type: `[item]`, where `item` has the shape:
+     *
+     * {
+     *   text: string,
+     *   action: function?,
+     * }
+     *
+     * If `action` is not present, it defaults to popping the stack to the
+     * depth of the breadcrumb item. The last breadcrumb item has no action by
+     * default.
+     */
     property var items
+
+
+    /**
+     * Type: `item` as described in `items` docstring
+     */
     property var root: ({
                             text: qsTr("Home")
                         })

--- a/ykman-gui/qml/BreadCrumbRow.qml
+++ b/ykman-gui/qml/BreadCrumbRow.qml
@@ -4,14 +4,11 @@ import QtQuick.Layouts 1.2
 RowLayout {
 
     property var items
-    property var root: ({
-                            text: qsTr("Home"),
-                            action: views.home
-                        })
+    property var root: ({ text: qsTr("Home") })
 
     BreadCrumb {
         text: root.text
-        action: root.action
+        action: items.length > 0 && function() { popToHeight(0) }
     }
 
     Repeater {
@@ -22,8 +19,10 @@ RowLayout {
             }
             BreadCrumb {
                 text: items[index].text
-                action: items[index].action
-                active: index == items.length - 1
+                action: !active && function() {
+                    popToHeight(index + 1)
+                }
+                active: index === items.length - 1
             }
         }
     }

--- a/ykman-gui/qml/ContentStack.qml
+++ b/ykman-gui/qml/ContentStack.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.2
+import "utils.js" as Utils
 
 StackView {
     anchors.fill: parent
@@ -50,44 +51,70 @@ StackView {
         return false
     }
 
-    function home() {
-        clear()
-        if (yubiKey.hasDevice) {
-            push(homeView)
-        } else if (yubiKey.nDevices > 1) {
-            push(multipleDevicesView)
+    function popToHeight(height) {
+        pop(find(function(item, searchIndex) {
+            return searchIndex === height;
+        }))
+    }
+
+    function replaceAtDepth(depth, item, objectName) {
+        var itemToReplace = find(function(item, index) {
+            return index === depth
+        })
+        if (itemToReplace) {
+            if (objectName) {
+                if (itemToReplace.objectName === objectName) {
+                    pop(itemToReplace)
+                } else {
+                    replace(itemToReplace, item)
+                }
+            } else {
+                replace(itemToReplace, item)
+            }
         } else {
-            push(noDeviceView)
+            push(item)
+        }
+    }
+
+    function home() {
+        if (yubiKey.hasDevice) {
+            var homeViewOnStack = find(function(item) { return item.objectName === 'homeView' })
+            if (homeViewOnStack) {
+                pop(homeViewOnStack)
+            } else {
+                replaceAtDepth(0, homeView, 'homeView')
+            }
+        } else if (yubiKey.nDevices > 1) {
+            replaceAtDepth(0, multipleDevicesView, 'multipleDevicesView')
+        } else {
+            replaceAtDepth(0, noDeviceView, 'noDeviceView')
         }
     }
 
     function configureInterfaces() {
         var interfaceComponent = yubiKey.supportsNewInterfaces(
                     ) ? interfaces : legacyInterfaces
-        clear()
-        push(interfaceComponent)
+        replaceAtDepth(1, interfaceComponent, 'interfaces')
     }
 
     function fido2() {
-        clear()
-        push(fido2View)
+        replaceAtDepth(1, fido2View, 'fido2View')
     }
 
     function fido2SetPin() {
-        push(fido2SetPinView)
+        replaceAtDepth(2, fido2SetPinView, 'fido2SetPinView')
     }
 
     function fido2ChangePin() {
-        push(fido2ChangePinView)
+        replaceAtDepth(2, fido2ChangePinView, 'fido2ChangePinView')
     }
 
     function fido2Reset() {
-        push(fido2ResetView)
+        replaceAtDepth(2, fido2ResetView, 'fido2ResetView')
     }
 
     function otp() {
-        clear()
-        push(otpViewComponent)
+        replaceAtDepth(1, otpViewComponent, 'otpView')
     }
 
     function otpSuccess() {

--- a/ykman-gui/qml/ContentStack.qml
+++ b/ykman-gui/qml/ContentStack.qml
@@ -52,13 +52,13 @@ StackView {
     }
 
     function popToDepth(height) {
-        pop(find(function(item, searchIndex) {
-            return searchIndex === height;
+        pop(find(function (item, searchIndex) {
+            return searchIndex === height
         }))
     }
 
     function replaceAtDepth(depth, item, objectName) {
-        var itemToReplace = find(function(item, index) {
+        var itemToReplace = find(function (item, index) {
             return index === depth
         })
         if (itemToReplace) {
@@ -78,7 +78,9 @@ StackView {
 
     function home() {
         if (yubiKey.hasDevice) {
-            var homeViewOnStack = find(function(item) { return item.objectName === 'homeView' })
+            var homeViewOnStack = find(function (item) {
+                return item.objectName === 'homeView'
+            })
             if (homeViewOnStack) {
                 pop(homeViewOnStack)
             } else {

--- a/ykman-gui/qml/ContentStack.qml
+++ b/ykman-gui/qml/ContentStack.qml
@@ -51,7 +51,7 @@ StackView {
         return false
     }
 
-    function popToHeight(height) {
+    function popToDepth(height) {
         pop(find(function(item, searchIndex) {
             return searchIndex === height;
         }))

--- a/ykman-gui/qml/ContentStack.qml
+++ b/ykman-gui/qml/ContentStack.qml
@@ -57,13 +57,13 @@ StackView {
         }))
     }
 
-    function replaceAtDepth(depth, item, objectName) {
+    function replaceAtDepth(depth, item, newObjectName) {
         var itemToReplace = find(function (item, index) {
             return index === depth
         })
         if (itemToReplace) {
-            if (objectName) {
-                if (itemToReplace.objectName === objectName) {
+            if (newObjectName) {
+                if (itemToReplace.objectName === newObjectName) {
                     pop(itemToReplace)
                 } else {
                     replace(itemToReplace, item)

--- a/ykman-gui/qml/Fido2ChangePinView.qml
+++ b/ykman-gui/qml/Fido2ChangePinView.qml
@@ -73,12 +73,10 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [{
-                        "text": qsTr("FIDO2"),
-                        "action": views.fido2
-                    }, {
-                        "text": qsTr("Change PIN")
-                    }]
+                items: [
+                    { text: qsTr("FIDO2") },
+                    { text: qsTr("Change PIN") },
+                ]
             }
         }
         GridLayout {

--- a/ykman-gui/qml/Fido2ChangePinView.qml
+++ b/ykman-gui/qml/Fido2ChangePinView.qml
@@ -73,10 +73,11 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("FIDO2") },
-                    { text: qsTr("Change PIN") },
-                ]
+                items: [{
+                        text: qsTr("FIDO2")
+                    }, {
+                        text: qsTr("Change PIN")
+                    }]
             }
         }
         GridLayout {

--- a/ykman-gui/qml/Fido2ChangePinView.qml
+++ b/ykman-gui/qml/Fido2ChangePinView.qml
@@ -73,24 +73,12 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("FIDO2")
-                    action: views.fido2
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("Change PIN")
-                    active: true
-                }
+                items: [{
+                        "text": qsTr("FIDO2"),
+                        "action": views.fido2
+                    }, {
+                        "text": qsTr("Change PIN")
+                    }]
             }
         }
         GridLayout {

--- a/ykman-gui/qml/Fido2ResetView.qml
+++ b/ykman-gui/qml/Fido2ResetView.qml
@@ -60,10 +60,11 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("FIDO2") },
-                    { text: qsTr("Reset FIDO") },
-                ]
+                items: [{
+                        text: qsTr("FIDO2")
+                    }, {
+                        text: qsTr("Reset FIDO")
+                    }]
             }
         }
 

--- a/ykman-gui/qml/Fido2ResetView.qml
+++ b/ykman-gui/qml/Fido2ResetView.qml
@@ -60,24 +60,10 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("FIDO2")
-                    action: views.fido2
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("Reset FIDO")
-                    active: true
-                }
+                items: [
+                    { text: qsTr("FIDO2"), action: views.fido2 },
+                    { text: qsTr("Reset FIDO") },
+                ]
             }
         }
 

--- a/ykman-gui/qml/Fido2ResetView.qml
+++ b/ykman-gui/qml/Fido2ResetView.qml
@@ -61,7 +61,7 @@ ColumnLayout {
 
             BreadCrumbRow {
                 items: [
-                    { text: qsTr("FIDO2"), action: views.fido2 },
+                    { text: qsTr("FIDO2") },
                     { text: qsTr("Reset FIDO") },
                 ]
             }

--- a/ykman-gui/qml/Fido2SetPinView.qml
+++ b/ykman-gui/qml/Fido2SetPinView.qml
@@ -45,10 +45,11 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("FIDO2") },
-                    { text: qsTr("Set PIN") },
-                ]
+                items: [{
+                        text: qsTr("FIDO2")
+                    }, {
+                        text: qsTr("Set PIN")
+                    }]
             }
         }
         GridLayout {

--- a/ykman-gui/qml/Fido2SetPinView.qml
+++ b/ykman-gui/qml/Fido2SetPinView.qml
@@ -46,7 +46,7 @@ ColumnLayout {
 
             BreadCrumbRow {
                 items: [
-                    { text: qsTr("FIDO2"), action: views.fido2 },
+                    { text: qsTr("FIDO2") },
                     { text: qsTr("Set PIN") },
                 ]
             }

--- a/ykman-gui/qml/Fido2SetPinView.qml
+++ b/ykman-gui/qml/Fido2SetPinView.qml
@@ -45,24 +45,10 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("FIDO2")
-                    action: views.fido2
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("Set PIN")
-                    active: true
-                }
+                items: [
+                    { text: qsTr("FIDO2"), action: views.fido2 },
+                    { text: qsTr("Set PIN") },
+                ]
             }
         }
         GridLayout {

--- a/ykman-gui/qml/Fido2View.qml
+++ b/ykman-gui/qml/Fido2View.qml
@@ -70,17 +70,9 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("FIDO2")
-                    active: true
-                }
+                items: [
+                    { text: qsTr("FIDO2") },
+                ]
             }
         }
 

--- a/ykman-gui/qml/Fido2View.qml
+++ b/ykman-gui/qml/Fido2View.qml
@@ -70,9 +70,9 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("FIDO2") },
-                ]
+                items: [{
+                        text: qsTr("FIDO2")
+                    }]
             }
         }
 

--- a/ykman-gui/qml/Fido2View.qml
+++ b/ykman-gui/qml/Fido2View.qml
@@ -12,7 +12,7 @@ ColumnLayout {
     property int pinRetries
     property bool isBusy
 
-    Component.onCompleted: load()
+    StackView.onActivating: load()
 
     objectName: "fido2View"
 

--- a/ykman-gui/qml/InterfaceView.qml
+++ b/ykman-gui/qml/InterfaceView.qml
@@ -32,7 +32,7 @@ ColumnLayout {
             name: qsTr("OATH")
         }]
 
-    Component.onCompleted: load()
+    StackView.onActivating: load()
 
     function configureInterfaces() {
         if (yubiKey.configurationLocked) {

--- a/ykman-gui/qml/InterfaceView.qml
+++ b/ykman-gui/qml/InterfaceView.qml
@@ -142,18 +142,9 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("Interfaces")
-                    active: true
-                }
+                items: [
+                    { text: qsTr("Interfaces") },
+                ]
             }
         }
 

--- a/ykman-gui/qml/InterfaceView.qml
+++ b/ykman-gui/qml/InterfaceView.qml
@@ -142,9 +142,9 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("Interfaces") },
-                ]
+                items: [{
+                        text: qsTr("Interfaces")
+                    }]
             }
         }
 

--- a/ykman-gui/qml/LegacyInterfaceView.qml
+++ b/ykman-gui/qml/LegacyInterfaceView.qml
@@ -62,18 +62,9 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("Interfaces")
-                    active: true
-                }
+                items: [
+                    { text: qsTr("Interfaces") },
+                ]
             }
         }
 

--- a/ykman-gui/qml/LegacyInterfaceView.qml
+++ b/ykman-gui/qml/LegacyInterfaceView.qml
@@ -62,9 +62,9 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("Interfaces") },
-                ]
+                items: [{
+                        text: qsTr("Interfaces")
+                    }]
             }
         }
 

--- a/ykman-gui/qml/LegacyInterfaceView.qml
+++ b/ykman-gui/qml/LegacyInterfaceView.qml
@@ -6,7 +6,7 @@ import QtQuick.Controls.Material 2.2
 
 ColumnLayout {
     objectName: "interfaces"
-    Component.onCompleted: load()
+    StackView.onActivating: load()
     function load() {
         otp.checked = Utils.includes(yubiKey.usbInterfacesEnabled, 'OTP')
         fido.checked = Utils.includes(yubiKey.usbInterfacesEnabled, 'FIDO')

--- a/ykman-gui/qml/OtpChalRespView.qml
+++ b/ykman-gui/qml/OtpChalRespView.qml
@@ -54,8 +54,8 @@ ColumnLayout {
                 items: [{
                         text: qsTr("OTP")
                     }, {
-                        text: qsTr(SlotUtils.slotNameCapitalized(
-                                         views.selectedSlot))
+                        text: SlotUtils.slotNameCapitalized(
+                                    views.selectedSlot)
                     }, {
                         text: qsTr("Challenge-response")
                     }]

--- a/ykman-gui/qml/OtpChalRespView.qml
+++ b/ykman-gui/qml/OtpChalRespView.qml
@@ -51,41 +51,12 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("OTP")
-                    action: views.otp
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr(SlotUtils.slotNameCapitalized(
-                                   views.selectedSlot))
-                    action: views.otp
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("Select Credential Type")
-                    action: views.pop
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("Challenge-response")
-                    active: true
-                }
+                items: [
+                    { text: qsTr("OTP"), action: views.otp },
+                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)), action: views.otp },
+                    { text: qsTr("Select Credential Type"), action: views.pop },
+                    { text: qsTr("Challenge-response") },
+                ]
             }
         }
         RowLayout {

--- a/ykman-gui/qml/OtpChalRespView.qml
+++ b/ykman-gui/qml/OtpChalRespView.qml
@@ -52,9 +52,8 @@ ColumnLayout {
 
             BreadCrumbRow {
                 items: [
-                    { text: qsTr("OTP"), action: views.otp },
-                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)), action: views.otp },
-                    { text: qsTr("Select Credential Type"), action: views.pop },
+                    { text: qsTr("OTP") },
+                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)) },
                     { text: qsTr("Challenge-response") },
                 ]
             }

--- a/ykman-gui/qml/OtpChalRespView.qml
+++ b/ykman-gui/qml/OtpChalRespView.qml
@@ -55,7 +55,7 @@ ColumnLayout {
                         text: qsTr("OTP")
                     }, {
                         text: SlotUtils.slotNameCapitalized(
-                                    views.selectedSlot)
+                                    views.selectedSlot) || ""
                     }, {
                         text: qsTr("Challenge-response")
                     }]

--- a/ykman-gui/qml/OtpChalRespView.qml
+++ b/ykman-gui/qml/OtpChalRespView.qml
@@ -51,11 +51,14 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("OTP") },
-                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)) },
-                    { text: qsTr("Challenge-response") },
-                ]
+                items: [{
+                        text: qsTr("OTP")
+                    }, {
+                        text: qsTr(SlotUtils.slotNameCapitalized(
+                                         views.selectedSlot))
+                    }, {
+                        text: qsTr("Challenge-response")
+                    }]
             }
         }
         RowLayout {

--- a/ykman-gui/qml/OtpConfigureSlotView.qml
+++ b/ykman-gui/qml/OtpConfigureSlotView.qml
@@ -16,9 +16,8 @@ ColumnLayout {
 
             BreadCrumbRow {
                 items: [
-                    { text: qsTr("OTP"), action: views.otp },
-                    { text: SlotUtils.slotNameCapitalized(views.selectedSlot), action: views.otp },
-                    { text: qsTr("Select Credential Type") },
+                    { text: qsTr("OTP") },
+                    { text: SlotUtils.slotNameCapitalized(views.selectedSlot) },
                 ]
             }
         }

--- a/ykman-gui/qml/OtpConfigureSlotView.qml
+++ b/ykman-gui/qml/OtpConfigureSlotView.qml
@@ -15,28 +15,11 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("OTP")
-                    action: views.otp
-                }
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: SlotUtils.slotNameCapitalized(views.selectedSlot)
-                    action: views.otp
-                }
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("Select Credential Type")
-                    active: true
-                }
+                items: [
+                    { text: qsTr("OTP"), action: views.otp },
+                    { text: SlotUtils.slotNameCapitalized(views.selectedSlot), action: views.otp },
+                    { text: qsTr("Select Credential Type") },
+                ]
             }
         }
 

--- a/ykman-gui/qml/OtpConfigureSlotView.qml
+++ b/ykman-gui/qml/OtpConfigureSlotView.qml
@@ -19,7 +19,7 @@ ColumnLayout {
                         text: qsTr("OTP")
                     }, {
                         text: SlotUtils.slotNameCapitalized(
-                                    views.selectedSlot)
+                                    views.selectedSlot) || ""
                     }]
             }
         }

--- a/ykman-gui/qml/OtpConfigureSlotView.qml
+++ b/ykman-gui/qml/OtpConfigureSlotView.qml
@@ -15,10 +15,12 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("OTP") },
-                    { text: SlotUtils.slotNameCapitalized(views.selectedSlot) },
-                ]
+                items: [{
+                        text: qsTr("OTP")
+                    }, {
+                        text: SlotUtils.slotNameCapitalized(
+                                    views.selectedSlot)
+                    }]
             }
         }
 

--- a/ykman-gui/qml/OtpOathHotpView.qml
+++ b/ykman-gui/qml/OtpOathHotpView.qml
@@ -47,7 +47,7 @@ ColumnLayout {
                         text: qsTr("OTP")
                     }, {
                         text: SlotUtils.slotNameCapitalized(
-                                    views.selectedSlot)
+                                    views.selectedSlot) || ""
                     }, {
                         text: qsTr("OATH-HOTP")
                     }]

--- a/ykman-gui/qml/OtpOathHotpView.qml
+++ b/ykman-gui/qml/OtpOathHotpView.qml
@@ -43,41 +43,12 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("OTP")
-                    action: views.otp
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr(SlotUtils.slotNameCapitalized(
-                                   views.selectedSlot))
-                    action: views.otp
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("Select Credential Type")
-                    action: views.pop
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("OATH-HOTP")
-                    active: true
-                }
+                items: [
+                    { text: qsTr("OTP"), action: views.otp },
+                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)), action: views.otp },
+                    { text: qsTr("Select Credential Type"), action: views.pop },
+                    { text: qsTr("OATH-HOTP") },
+                ]
             }
         }
         RowLayout {

--- a/ykman-gui/qml/OtpOathHotpView.qml
+++ b/ykman-gui/qml/OtpOathHotpView.qml
@@ -43,11 +43,14 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("OTP") },
-                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)) },
-                    { text: qsTr("OATH-HOTP") },
-                ]
+                items: [{
+                        text: qsTr("OTP")
+                    }, {
+                        text: qsTr(SlotUtils.slotNameCapitalized(
+                                         views.selectedSlot))
+                    }, {
+                        text: qsTr("OATH-HOTP")
+                    }]
             }
         }
         RowLayout {

--- a/ykman-gui/qml/OtpOathHotpView.qml
+++ b/ykman-gui/qml/OtpOathHotpView.qml
@@ -44,9 +44,8 @@ ColumnLayout {
 
             BreadCrumbRow {
                 items: [
-                    { text: qsTr("OTP"), action: views.otp },
-                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)), action: views.otp },
-                    { text: qsTr("Select Credential Type"), action: views.pop },
+                    { text: qsTr("OTP") },
+                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)) },
                     { text: qsTr("OATH-HOTP") },
                 ]
             }

--- a/ykman-gui/qml/OtpOathHotpView.qml
+++ b/ykman-gui/qml/OtpOathHotpView.qml
@@ -46,8 +46,8 @@ ColumnLayout {
                 items: [{
                         text: qsTr("OTP")
                     }, {
-                        text: qsTr(SlotUtils.slotNameCapitalized(
-                                         views.selectedSlot))
+                        text: SlotUtils.slotNameCapitalized(
+                                    views.selectedSlot)
                     }, {
                         text: qsTr("OATH-HOTP")
                     }]

--- a/ykman-gui/qml/OtpStaticPasswordView.qml
+++ b/ykman-gui/qml/OtpStaticPasswordView.qml
@@ -65,8 +65,8 @@ ColumnLayout {
                 items: [{
                         text: qsTr("OTP")
                     }, {
-                        text: qsTr(SlotUtils.slotNameCapitalized(
-                                         views.selectedSlot))
+                        text: SlotUtils.slotNameCapitalized(
+                                    views.selectedSlot)
                     }, {
                         text: qsTr("Static Password")
                     }]

--- a/ykman-gui/qml/OtpStaticPasswordView.qml
+++ b/ykman-gui/qml/OtpStaticPasswordView.qml
@@ -66,7 +66,7 @@ ColumnLayout {
                         text: qsTr("OTP")
                     }, {
                         text: SlotUtils.slotNameCapitalized(
-                                    views.selectedSlot)
+                                    views.selectedSlot) || ""
                     }, {
                         text: qsTr("Static Password")
                     }]

--- a/ykman-gui/qml/OtpStaticPasswordView.qml
+++ b/ykman-gui/qml/OtpStaticPasswordView.qml
@@ -63,9 +63,8 @@ ColumnLayout {
 
             BreadCrumbRow {
                 items: [
-                    { text: qsTr("OTP"), action: views.otp },
-                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)), action: views.otp },
-                    { text: qsTr("Select Credential Type"), action: views.pop },
+                    { text: qsTr("OTP") },
+                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)) },
                     { text: qsTr("Static Password") },
                 ]
             }

--- a/ykman-gui/qml/OtpStaticPasswordView.qml
+++ b/ykman-gui/qml/OtpStaticPasswordView.qml
@@ -62,11 +62,14 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("OTP") },
-                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)) },
-                    { text: qsTr("Static Password") },
-                ]
+                items: [{
+                        text: qsTr("OTP")
+                    }, {
+                        text: qsTr(SlotUtils.slotNameCapitalized(
+                                         views.selectedSlot))
+                    }, {
+                        text: qsTr("Static Password")
+                    }]
             }
         }
 

--- a/ykman-gui/qml/OtpStaticPasswordView.qml
+++ b/ykman-gui/qml/OtpStaticPasswordView.qml
@@ -62,41 +62,12 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("OTP")
-                    action: views.otp
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr(SlotUtils.slotNameCapitalized(
-                                   views.selectedSlot))
-                    action: views.otp
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("Select Credential Type")
-                    action: views.pop
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("Static Password")
-                    active: true
-                }
+                items: [
+                    { text: qsTr("OTP"), action: views.otp },
+                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)), action: views.otp },
+                    { text: qsTr("Select Credential Type"), action: views.pop },
+                    { text: qsTr("Static Password") },
+                ]
             }
         }
 

--- a/ykman-gui/qml/OtpView.qml
+++ b/ykman-gui/qml/OtpView.qml
@@ -95,18 +95,7 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("OTP")
-                    active: true
-                }
+                items: [{ text: qsTr("OTP") }]
             }
         }
 

--- a/ykman-gui/qml/OtpView.qml
+++ b/ykman-gui/qml/OtpView.qml
@@ -10,7 +10,7 @@ ColumnLayout {
     readonly property string slotIsConfigured: qsTr("This slot is configured")
     readonly property string slotIsEmpty: qsTr("This slot is empty")
 
-    Component.onCompleted: load()
+    StackView.onActivating: load()
     objectName: "otpView"
 
     function load() {
@@ -45,6 +45,7 @@ ColumnLayout {
         yubiKey.erase_slot(views.selectedSlot, function (resp) {
             if (resp.success) {
                 views.otpSuccess()
+                load()
             } else {
                 if (resp.error === 'write error') {
                     views.otpWriteError()
@@ -59,6 +60,7 @@ ColumnLayout {
         yubiKey.swap_slots(function (resp) {
             if (resp.success) {
                 views.otpSuccess()
+                load()
             } else {
                 if (resp.error === 'write error') {
                     views.otpWriteError()

--- a/ykman-gui/qml/OtpView.qml
+++ b/ykman-gui/qml/OtpView.qml
@@ -97,7 +97,9 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [{ text: qsTr("OTP") }]
+                items: [{
+                        text: qsTr("OTP")
+                    }]
             }
         }
 

--- a/ykman-gui/qml/OtpYubiOtpView.qml
+++ b/ykman-gui/qml/OtpYubiOtpView.qml
@@ -70,7 +70,7 @@ ColumnLayout {
                         text: qsTr("OTP")
                     }, {
                         text: SlotUtils.slotNameCapitalized(
-                                    views.selectedSlot)
+                                    views.selectedSlot) || ""
                     }, {
                         text: qsTr("Yubico OTP")
                     }]

--- a/ykman-gui/qml/OtpYubiOtpView.qml
+++ b/ykman-gui/qml/OtpYubiOtpView.qml
@@ -69,8 +69,8 @@ ColumnLayout {
                 items: [{
                         text: qsTr("OTP")
                     }, {
-                        text: qsTr(SlotUtils.slotNameCapitalized(
-                                         views.selectedSlot))
+                        text: SlotUtils.slotNameCapitalized(
+                                    views.selectedSlot)
                     }, {
                         text: qsTr("Yubico OTP")
                     }]

--- a/ykman-gui/qml/OtpYubiOtpView.qml
+++ b/ykman-gui/qml/OtpYubiOtpView.qml
@@ -66,41 +66,12 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                BreadCrumb {
-                    text: qsTr("Home")
-                    action: views.home
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr("OTP")
-                    action: views.otp
-                }
-
-                BreadCrumbSeparator {
-                }
-                BreadCrumb {
-                    text: qsTr(SlotUtils.slotNameCapitalized(
-                                   views.selectedSlot))
-                    action: views.otp
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("Select Credential Type")
-                    action: views.pop
-                }
-
-                BreadCrumbSeparator {
-                }
-
-                BreadCrumb {
-                    text: qsTr("Yubico OTP")
-                    active: true
-                }
+                items: [
+                    { text: qsTr("OTP"), action: views.otp },
+                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)), action: views.otp },
+                    { text: qsTr("Select Credential Type"), action: views.pop },
+                    { text: qsTr("Yubico OTP") },
+                ]
             }
         }
         GridLayout {

--- a/ykman-gui/qml/OtpYubiOtpView.qml
+++ b/ykman-gui/qml/OtpYubiOtpView.qml
@@ -66,11 +66,14 @@ ColumnLayout {
             }
 
             BreadCrumbRow {
-                items: [
-                    { text: qsTr("OTP") },
-                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)) },
-                    { text: qsTr("Yubico OTP") },
-                ]
+                items: [{
+                        text: qsTr("OTP")
+                    }, {
+                        text: qsTr(SlotUtils.slotNameCapitalized(
+                                         views.selectedSlot))
+                    }, {
+                        text: qsTr("Yubico OTP")
+                    }]
             }
         }
         GridLayout {

--- a/ykman-gui/qml/OtpYubiOtpView.qml
+++ b/ykman-gui/qml/OtpYubiOtpView.qml
@@ -67,9 +67,8 @@ ColumnLayout {
 
             BreadCrumbRow {
                 items: [
-                    { text: qsTr("OTP"), action: views.otp },
-                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)), action: views.otp },
-                    { text: qsTr("Select Credential Type"), action: views.pop },
+                    { text: qsTr("OTP") },
+                    { text: qsTr(SlotUtils.slotNameCapitalized(views.selectedSlot)) },
                     { text: qsTr("Yubico OTP") },
                 ]
             }

--- a/ykman-gui/qml/slotutils.js
+++ b/ykman-gui/qml/slotutils.js
@@ -7,9 +7,9 @@ function slotName(slotNumber) {
 
 function slotNameCapitalized(slotNumber) {
     if (slotNumber === 1)
-        return "Short Touch (Slot 1)"
+        return qsTr("Short Touch (Slot 1)")
     if (slotNumber === 2)
-        return "Long Touch (Slot 2)"
+        return qsTr("Long Touch (Slot 2)")
 }
 
 function configuredTxt(configured) {

--- a/ykman-gui/qml/utils.js
+++ b/ykman-gui/qml/utils.js
@@ -23,6 +23,10 @@ function including(arr, value) {
     }
 }
 
+function last(arr) {
+    return arr[arr.length - 1];
+}
+
 /**
  * Remove `value` from `arr`.
  *


### PR DESCRIPTION
This PR does a couple of kind of separate, but related, things:

- Generate breadcrumbs from dynamic JS object models

  This will enable us to extract a generic `ChangePinView` from `Fido2{Set,Change}PinView`, by enabling the `ChangePinView` to accept the breadcrumbs model as a parameter.

- Make navigation transitions smoother
  - Use StackView's `pop` and `replace` methods instead of `clear`. This allows the StackView to apply suitable animations to all the view transitions.
  - Make breadcrumbs always pop N items off the StackView, instead of having each item define its own action. This makes the breadcrumbs less brittle and more portable, assuming all views follow the same navigation paradigm.
    - As a result the "Select Credential Type" breadcrumbs have been removed from the OTP configuration views, to make the breadcrumbs reflect the stack layout.

- Reload views when navigating to them (for example, when returning to Fido2View from Fido2ResetView), or when they update their own underlying data model (for example, after OtpView swaps credentials)