### PR TITLE
prefer 'success' in response to indicate success

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -173,15 +173,18 @@ class Controller(object):
     def slots_status(self):
         try:
             with self._open_otp_controller() as controller:
-                return {'status': controller.slot_status, 'error': None}
+                return {
+                    'success': True,
+                    'status': controller.slot_status,
+                    'error': None}
         except YkpersError as e:
             if e.errno == 4:
-                return {'status': None, 'error': 'timeout'}
+                return {'success': False, 'status': None, 'error': 'timeout'}
             logger.error('Failed to read slot status', exc_info=e)
-            return {'status': None, 'error': str(e)}
+            return {'success': False, 'status': None, 'error': str(e)}
         except Exception as e:
             logger.error('Failed to read slot status', exc_info=e)
-            return {'status': None, 'error': str(e)}
+            return {'success': False, 'status': None, 'error': str(e)}
 
     def erase_slot(self, slot):
         try:
@@ -280,26 +283,36 @@ class Controller(object):
     def fido_has_pin(self):
         try:
             with self._open_fido2_controller() as controller:
-                return {'hasPin': controller.has_pin, 'error': None}
+                return {
+                    'success': True,
+                    'hasPin': controller.has_pin,
+                    'error': None}
         except Exception as e:
             logger.error('Failed to read if PIN is set', exc_info=e)
-            return {'hasPin': None, 'error': str(e)}
+            return {'success': False, 'hasPin': None, 'error': str(e)}
 
     def fido_pin_retries(self):
         try:
             with self._open_fido2_controller() as controller:
-                return {'retries': controller.get_pin_retries(), 'error': None}
+                return {
+                    'success': True,
+                    'retries': controller.get_pin_retries(),
+                    'error': None}
         except CtapError as e:
             if e.code == CtapError.ERR.PIN_AUTH_BLOCKED:
                 return {
+                    'success': False,
                     'retries': None,
                     'error': 'PIN authentication is currently blocked. '
                              'Remove and re-insert the YubiKey.'}
             if e.code == CtapError.ERR.PIN_BLOCKED:
-                return {'retries': None, 'error': 'PIN is blocked.'}
+                return {
+                    'success': False,
+                    'retries': None,
+                    'error': 'PIN is blocked.'}
         except Exception as e:
             logger.error('Failed to read PIN retries', exc_info=e)
-            return {'retries': None, 'error': str(e)}
+            return {'success': False, 'retries': None, 'error': str(e)}
 
     def fido_set_pin(self, new_pin):
         try:

--- a/ykman-gui/qml/Fido2View.qml
+++ b/ykman-gui/qml/Fido2View.qml
@@ -19,11 +19,11 @@ ColumnLayout {
     function load() {
         isBusy = true
         yubiKey.fido_has_pin(function (resp) {
-            if (!resp.error) {
+            if (resp.success) {
                 hasPin = resp.hasPin
                 if (hasPin) {
                     yubiKey.fido_pin_retries(function (resp) {
-                        if (!resp.error) {
+                        if (resp.success) {
                             pinRetries = resp.retries
                         } else {
                             console.log(resp.error)
@@ -36,8 +36,7 @@ ColumnLayout {
                     isBusy = false
                 }
             } else {
-                console.log(resp.error)
-                isBusy = false
+                views.home()
             }
         })
     }

--- a/ykman-gui/qml/OtpView.qml
+++ b/ykman-gui/qml/OtpView.qml
@@ -16,7 +16,7 @@ ColumnLayout {
     function load() {
         isBusy = true
         yubiKey.slots_status(function (resp) {
-            if (!resp.error) {
+            if (resp.success) {
                 views.slot1Configured = resp.status[0]
                 views.slot2Configured = resp.status[1]
                 views.selectedSlot = 0

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -199,7 +199,7 @@ Python {
             nDevices = n
             if (nDevices == 1) {
                 do_call('yubikey.controller.refresh', [], function (resp) {
-                    if (!resp.error && resp.dev) {
+                    if (resp.success && resp.dev) {
                         hasDevice = true
                         name = resp.dev.name
                         version = resp.dev.version


### PR DESCRIPTION
It's dangerous to rely on the `error` property in the responses from yubikey.py since it might be empty for some Exceptions. `Fido2View.qml` had the wrong behavior in some cases because of this.

Proposed solution is to always set `success` to True or False before returning from the python layer. 