### PR TITLE
interfaces: add error popup for mode switch

### DIFF
--- a/ykman-gui/qml/LegacyInterfaceErrorPopup.qml
+++ b/ykman-gui/qml/LegacyInterfaceErrorPopup.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.2
+
+InlinePopup {
+
+    Heading2 {
+        width: parent.width
+        text: qsTr("Error!
+
+Failed to configure interfaces.
+
+Make sure the YubiKey does not have restricted access.")
+        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+        wrapMode: Text.WordWrap
+    }
+
+    standardButtons: Dialog.Ok
+}

--- a/ykman-gui/qml/LegacyInterfaceErrorPopup.qml
+++ b/ykman-gui/qml/LegacyInterfaceErrorPopup.qml
@@ -3,17 +3,21 @@ import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.2
 
 InlinePopup {
-
-    Heading2 {
-        width: parent.width
-        text: qsTr("Error!
-
-Failed to configure interfaces.
-
-Make sure the YubiKey does not have restricted access.")
-        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-        wrapMode: Text.WordWrap
+    contentHeight: msg.implicitHeight + title.implicitHeight
+    ColumnLayout {
+        anchors.fill: parent
+        Heading2 {
+            id: title
+            text: qsTr("Error!")
+            wrapMode: Text.WordWrap
+            Layout.alignment: Qt.AlignHCenter
+        }
+        Heading2 {
+            id: msg
+            Layout.maximumWidth: parent.width
+            text: qsTr("Failed to configure interfaces. Make sure the YubiKey does not have restricted access.")
+            wrapMode: Text.WordWrap
+        }
     }
-
     standardButtons: Dialog.Ok
 }

--- a/ykman-gui/qml/LegacyInterfaceView.qml
+++ b/ykman-gui/qml/LegacyInterfaceView.qml
@@ -30,7 +30,7 @@ ColumnLayout {
     function configureInterfaces() {
         yubiKey.set_mode(getEnabledInterfaces(), function (error) {
             if (error) {
-                console.log(error)
+                legacyInterfacesErrorPopup.open()
             } else {
                 if (!yubiKey.canWriteConfig) {
                     reInsertYubiKey.open()
@@ -51,6 +51,10 @@ ColumnLayout {
 
     function validCombination() {
         return otp.checked || fido.checked || ccid.checked
+    }
+
+    LegacyInterfaceErrorPopup {
+        id: legacyInterfacesErrorPopup
     }
 
     CustomContentColumn {


### PR DESCRIPTION
when legacy interface configuration failed (for example because of an access code) no error message was being shown to the user.