### PR TITLE
style: don't use snake_case in .qml files

### DIFF
--- a/ykman-gui/qml/Fido2ChangePinView.qml
+++ b/ykman-gui/qml/Fido2ChangePinView.qml
@@ -14,7 +14,7 @@ ColumnLayout {
     }
 
     function changePin() {
-        yubiKey.fido_change_pin(chosenCurrentPin, chosenPin, function (resp) {
+        yubiKey.fidoChangePin(chosenCurrentPin, chosenPin, function (resp) {
             if (resp.success) {
                 fido2SuccessPopup.open()
             } else {

--- a/ykman-gui/qml/Fido2ResetView.qml
+++ b/ykman-gui/qml/Fido2ResetView.qml
@@ -16,7 +16,7 @@ ColumnLayout {
             if (loadedReset) {
                 loadedReset = false
                 touchYubiKey.open()
-                yubiKey.fido_reset(function (resp) {
+                yubiKey.fidoReset(function (resp) {
                     touchYubiKey.close()
                     if (resp.success) {
                         fido2SuccessPopup.open()

--- a/ykman-gui/qml/Fido2SetPinView.qml
+++ b/ykman-gui/qml/Fido2SetPinView.qml
@@ -13,7 +13,7 @@ ColumnLayout {
     }
 
     function setPin() {
-        yubiKey.fido_set_pin(chosenPin, function (resp) {
+        yubiKey.fidoSetPin(chosenPin, function (resp) {
             if (resp.success) {
                 fido2SuccessPopup.open()
             } else {

--- a/ykman-gui/qml/Fido2View.qml
+++ b/ykman-gui/qml/Fido2View.qml
@@ -18,11 +18,11 @@ ColumnLayout {
 
     function load() {
         isBusy = true
-        yubiKey.fido_has_pin(function (resp) {
+        yubiKey.fidoHasPin(function (resp) {
             if (resp.success) {
                 hasPin = resp.hasPin
                 if (hasPin) {
-                    yubiKey.fido_pin_retries(function (resp) {
+                    yubiKey.fidoPinRetries(function (resp) {
                         if (resp.success) {
                             pinRetries = resp.retries
                         } else {

--- a/ykman-gui/qml/InterfaceView.qml
+++ b/ykman-gui/qml/InterfaceView.qml
@@ -44,7 +44,7 @@ ColumnLayout {
 
     function writeInterfaces() {
         views.lock()
-        yubiKey.write_config(newApplicationsEnabledOverUsb,
+        yubiKey.writeConfig(newApplicationsEnabledOverUsb,
                              newApplicationsEnabledOverNfc, lockCode,
                              function (resp) {
                                  if (resp.success) {

--- a/ykman-gui/qml/LegacyInterfaceView.qml
+++ b/ykman-gui/qml/LegacyInterfaceView.qml
@@ -28,7 +28,7 @@ ColumnLayout {
     }
 
     function configureInterfaces() {
-        yubiKey.set_mode(getEnabledInterfaces(), function (error) {
+        yubiKey.setMode(getEnabledInterfaces(), function (error) {
             if (error) {
                 legacyInterfacesErrorPopup.open()
             } else {

--- a/ykman-gui/qml/OtpChalRespView.qml
+++ b/ykman-gui/qml/OtpChalRespView.qml
@@ -7,7 +7,7 @@ import QtQuick.Controls.Material 2.2
 ColumnLayout {
 
     function generateKey() {
-        yubiKey.random_key(20, function (res) {
+        yubiKey.randomKey(20, function (res) {
             secretKeyInput.text = res
         })
     }
@@ -21,7 +21,7 @@ ColumnLayout {
     }
 
     function programChallengeResponse() {
-        yubiKey.program_challenge_response(views.selectedSlot,
+        yubiKey.programChallengeResponse(views.selectedSlot,
                                            secretKeyInput.text,
                                            requireTouchCb.checked,
                                            function (resp) {

--- a/ykman-gui/qml/OtpOathHotpView.qml
+++ b/ykman-gui/qml/OtpOathHotpView.qml
@@ -15,7 +15,7 @@ ColumnLayout {
     }
 
     function programOathHotp() {
-        yubiKey.program_oath_hotp(views.selectedSlot, secretKeyInput.text,
+        yubiKey.programOathHotp(views.selectedSlot, secretKeyInput.text,
                                   digits.currentText, function (resp) {
                                       if (resp.success) {
                                           views.otpSuccess()

--- a/ykman-gui/qml/OtpStaticPasswordView.qml
+++ b/ykman-gui/qml/OtpStaticPasswordView.qml
@@ -17,7 +17,7 @@ ColumnLayout {
     }
 
     function programStaticPassword() {
-        yubiKey.program_static_password(views.selectedSlot, passwordInput.text,
+        yubiKey.programStaticPassword(views.selectedSlot, passwordInput.text,
                                         keyboardLayout, function (resp) {
                                             if (resp.success) {
                                                 views.otpSuccess()
@@ -33,7 +33,7 @@ ColumnLayout {
     }
 
     function generatePassword() {
-        yubiKey.generate_static_pw(keyboardLayout, function (res) {
+        yubiKey.generateStaticPw(keyboardLayout, function (res) {
             passwordInput.text = res
         })
     }

--- a/ykman-gui/qml/OtpView.qml
+++ b/ykman-gui/qml/OtpView.qml
@@ -15,7 +15,7 @@ ColumnLayout {
 
     function load() {
         isBusy = true
-        yubiKey.slots_status(function (resp) {
+        yubiKey.slotsStatus(function (resp) {
             if (resp.success) {
                 views.slot1Configured = resp.status[0]
                 views.slot2Configured = resp.status[1]
@@ -42,7 +42,7 @@ ColumnLayout {
     }
 
     function deleteSelectedSlot() {
-        yubiKey.erase_slot(views.selectedSlot, function (resp) {
+        yubiKey.eraseSlot(views.selectedSlot, function (resp) {
             if (resp.success) {
                 views.otpSuccess()
                 load()
@@ -57,7 +57,7 @@ ColumnLayout {
     }
 
     function swapConfigurations() {
-        yubiKey.swap_slots(function (resp) {
+        yubiKey.swapSlots(function (resp) {
             if (resp.success) {
                 views.otpSuccess()
                 load()

--- a/ykman-gui/qml/OtpYubiOtpView.qml
+++ b/ykman-gui/qml/OtpYubiOtpView.qml
@@ -8,20 +8,20 @@ ColumnLayout {
 
     function useSerial() {
         if (useSerialCb.checked) {
-            yubiKey.serial_modhex(function (res) {
+            yubiKey.serialModhex(function (res) {
                 publicIdInput.text = res
             })
         }
     }
 
     function generatePrivateId() {
-        yubiKey.random_uid(function (res) {
+        yubiKey.randomUid(function (res) {
             privateIdInput.text = res
         })
     }
 
     function generateKey() {
-        yubiKey.random_key(16, function (res) {
+        yubiKey.randomKey(16, function (res) {
             secretKeyInput.text = res
         })
     }
@@ -35,7 +35,7 @@ ColumnLayout {
     }
 
     function programYubiOtp() {
-        yubiKey.program_otp(views.selectedSlot, publicIdInput.text,
+        yubiKey.programOtp(views.selectedSlot, publicIdInput.text,
                             privateIdInput.text, secretKeyInput.text,
                             function (resp) {
                                 if (resp.success) {

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -43,13 +43,13 @@ Python {
     }
 
     onEnableLogging: {
-        do_call('yubikey.init_with_logging',
-                [logLevel || 'DEBUG', logFile || null], function () {
-                    yubikeyReady = true
-                })
+        doCall('yubikey.init_with_logging',
+               [logLevel || 'DEBUG', logFile || null], function () {
+                   yubikeyReady = true
+               })
     }
     onDisableLogging: {
-        do_call('yubikey.init', [], function () {
+        doCall('yubikey.init', [], function () {
             yubikeyReady = true
         })
     }
@@ -83,11 +83,11 @@ Python {
         var oldQueue = queue
         queue = []
         for (var i in oldQueue) {
-            do_call(oldQueue[i][0], oldQueue[i][1], oldQueue[i][2])
+            doCall(oldQueue[i][0], oldQueue[i][1], oldQueue[i][2])
         }
     }
 
-    function do_call(func, args, cb) {
+    function doCall(func, args, cb) {
         if (!isPythonReady(func)) {
             queue.push([func, args, cb])
         } else {
@@ -196,10 +196,10 @@ Python {
     }
 
     function refresh(doneCallback) {
-        do_call('yubikey.controller.count_devices', [], function (n) {
+        doCall('yubikey.controller.count_devices', [], function (n) {
             nDevices = n
             if (nDevices == 1) {
-                do_call('yubikey.controller.refresh', [], function (resp) {
+                doCall('yubikey.controller.refresh', [], function (resp) {
                     if (resp.success && resp.dev) {
                         hasDevice = true
                         name = resp.dev.name
@@ -227,83 +227,83 @@ Python {
         })
     }
 
-    function write_config(usbApplications, nfcApplications, lockCode, cb) {
-        do_call('yubikey.controller.write_config',
-                [usbApplications, nfcApplications, lockCode], cb)
+    function writeConfig(usbApplications, nfcApplications, lockCode, cb) {
+        doCall('yubikey.controller.write_config',
+               [usbApplications, nfcApplications, lockCode], cb)
     }
 
-    function set_mode(connections, cb) {
-        do_call('yubikey.controller.set_mode', [connections], cb)
+    function setMode(connections, cb) {
+        doCall('yubikey.controller.set_mode', [connections], cb)
     }
 
-    function slots_status(cb) {
-        do_call('yubikey.controller.slots_status', [], cb)
+    function slotsStatus(cb) {
+        doCall('yubikey.controller.slots_status', [], cb)
     }
 
-    function erase_slot(slot, cb) {
-        do_call('yubikey.controller.erase_slot', [slot], cb)
+    function eraseSlot(slot, cb) {
+        doCall('yubikey.controller.erase_slot', [slot], cb)
     }
 
-    function swap_slots(cb) {
-        do_call('yubikey.controller.swap_slots', [], cb)
+    function swapSlots(cb) {
+        doCall('yubikey.controller.swap_slots', [], cb)
     }
 
-    function serial_modhex(cb) {
-        do_call('yubikey.controller.serial_modhex', [], cb)
+    function serialModhex(cb) {
+        doCall('yubikey.controller.serial_modhex', [], cb)
     }
 
-    function random_uid(cb) {
-        do_call('yubikey.controller.random_uid', [], cb)
+    function randomUid(cb) {
+        doCall('yubikey.controller.random_uid', [], cb)
     }
 
-    function random_key(bytes, cb) {
-        do_call('yubikey.controller.random_key', [bytes], cb)
+    function randomKey(bytes, cb) {
+        doCall('yubikey.controller.random_key', [bytes], cb)
     }
 
-    function generate_static_pw(keyboard_layout, cb) {
-        do_call('yubikey.controller.generate_static_pw', [keyboard_layout], cb)
+    function generateStaticPw(keyboardLayout, cb) {
+        doCall('yubikey.controller.generate_static_pw', [keyboardLayout], cb)
     }
 
-    function program_otp(slot, public_id, private_id, key, cb) {
-        do_call('yubikey.controller.program_otp',
-                [slot, public_id, private_id, key], cb)
+    function programOtp(slot, publicId, privateId, key, cb) {
+        doCall('yubikey.controller.program_otp',
+               [slot, publicId, privateId, key], cb)
     }
 
-    function program_challenge_response(slot, key, touch, cb) {
-        do_call('yubikey.controller.program_challenge_response',
-                [slot, key, touch], cb)
+    function programChallengeResponse(slot, key, touch, cb) {
+        doCall('yubikey.controller.program_challenge_response',
+               [slot, key, touch], cb)
     }
 
-    function program_static_password(slot, password, keyboard_layout, cb) {
-        do_call('yubikey.controller.program_static_password',
-                [slot, password, keyboard_layout], cb)
+    function programStaticPassword(slot, password, keyboardLayout, cb) {
+        doCall('yubikey.controller.program_static_password',
+               [slot, password, keyboardLayout], cb)
     }
 
-    function program_oath_hotp(slot, key, digits, cb) {
-        do_call('yubikey.controller.program_oath_hotp', [slot, key, digits], cb)
+    function programOathHotp(slot, key, digits, cb) {
+        doCall('yubikey.controller.program_oath_hotp', [slot, key, digits], cb)
     }
 
-    function fido_support_ctap(cb) {
-        do_call('yubikey.controller.fido_support_ctap', [], cb)
+    function fidoSupportCtap(cb) {
+        doCall('yubikey.controller.fido_support_ctap', [], cb)
     }
 
-    function fido_has_pin(cb) {
-        do_call('yubikey.controller.fido_has_pin', [], cb)
+    function fidoHasPin(cb) {
+        doCall('yubikey.controller.fido_has_pin', [], cb)
     }
 
-    function fido_set_pin(newPin, cb) {
-        do_call('yubikey.controller.fido_set_pin', [newPin], cb)
+    function fidoSetPin(newPin, cb) {
+        doCall('yubikey.controller.fido_set_pin', [newPin], cb)
     }
 
-    function fido_change_pin(currentPin, newPin, cb) {
-        do_call('yubikey.controller.fido_change_pin', [currentPin, newPin], cb)
+    function fidoChangePin(currentPin, newPin, cb) {
+        doCall('yubikey.controller.fido_change_pin', [currentPin, newPin], cb)
     }
 
-    function fido_reset(cb) {
-        do_call('yubikey.controller.fido_reset', [], cb)
+    function fidoReset(cb) {
+        doCall('yubikey.controller.fido_reset', [], cb)
     }
 
-    function fido_pin_retries(cb) {
-        do_call('yubikey.controller.fido_pin_retries', [], cb)
+    function fidoPinRetries(cb) {
+        doCall('yubikey.controller.fido_pin_retries', [], cb)
     }
 }


### PR DESCRIPTION
Let's stick with QML/JS = camelCase and Python = snake_case