### PR TITLE
Restructure PIV cert properties

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -647,12 +647,12 @@ controller = None
 
 
 def _piv_serialise_cert(slot, cert):
-    issuer_common_names = cert.issuer.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
-    subject_common_names = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
+    issuer_cns = cert.issuer.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
+    subject_cns = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
     return {
         'slot': SLOT(slot).name,
-        'issuedFrom': issuer_common_names[0].value if issuer_common_names else '',
-        'issuedTo': subject_common_names[0].value if subject_common_names else '',
+        'issuedFrom': issuer_cns[0].value if issuer_cns else '',
+        'issuedTo': subject_cns[0].value if subject_cns else '',
         'validFrom': cert.not_valid_before.date().isoformat(),
         'validTo': cert.not_valid_after.date().isoformat()
     }

--- a/ykman-gui/qml/PivCertificateView.qml
+++ b/ykman-gui/qml/PivCertificateView.qml
@@ -2,6 +2,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import QtQuick.Controls.Material 2.2
+import "utils.js" as Utils
 
 ColumnLayout {
     id: pivCertificatesView
@@ -27,12 +28,7 @@ ColumnLayout {
             id: bar
             Layout.fillWidth: true
             Repeater {
-                model: [
-                    qsTr("Authentication"),
-                    qsTr("Digital Signature"),
-                    qsTr("Key Management"),
-                    qsTr("Card Authentication"),
-                ]
+                model: Utils.pick(yubiKey.pivSlots, "name")
 
                 TabButton {
                     text: modelData
@@ -48,25 +44,15 @@ ColumnLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             currentIndex: bar.currentIndex
-            PivCertificateInfo {
-                title: qsTr("Authentication (Slot 9a)")
-                slot: 'AUTHENTICATION'
-                certificate: yubiKey.authenticationCert
-            }
-            PivCertificateInfo {
-                title: qsTr("Digital Signature (Slot 9c)")
-                slot: 'SIGNATURE'
-                certificate: yubiKey.signatureCert
-            }
-            PivCertificateInfo {
-                title: qsTr("Key Management (Slot 9d)")
-                slot: 'KEY_MANAGEMENT'
-                certificate: yubiKey.keyManagementCert
-            }
-            PivCertificateInfo {
-                title: qsTr("Card Authentication (Slot 9e)")
-                slot: 'CARD_AUTH'
-                certificate: yubiKey.cardAuthenticationCert
+
+            Repeater {
+                model: yubiKey.pivSlots
+
+                PivCertificateInfo {
+                    title: qsTr("%1 (Slot %2)").arg(modelData.name).arg(modelData.hex)
+                    slot: modelData.id
+                    certificate: yubiKey.pivCerts[modelData.id]
+                }
             }
         }
         RowLayout {

--- a/ykman-gui/qml/PivCertificateView.qml
+++ b/ykman-gui/qml/PivCertificateView.qml
@@ -49,7 +49,8 @@ ColumnLayout {
                 model: yubiKey.pivSlots
 
                 PivCertificateInfo {
-                    title: qsTr("%1 (Slot %2)").arg(modelData.name).arg(modelData.hex)
+                    title: qsTr("%1 (Slot %2)").arg(modelData.name).arg(
+                               modelData.hex)
                     slot: modelData.id
                     certificate: yubiKey.pivCerts[modelData.id]
                 }

--- a/ykman-gui/qml/PivView.qml
+++ b/ykman-gui/qml/PivView.qml
@@ -16,14 +16,7 @@ ColumnLayout {
     function load() {
         isBusy = true
         yubiKey.pivListCertificates(function (resp) {
-            if (resp.success) {
-                var certs = {};
-                for (var i = 0; i < resp.certs.length; i++) {
-                    var cert = resp.certs[i]
-                    certs[cert.slot] = cert;
-                }
-                yubiKey.pivCerts = Utils.extend(yubiKey.pivCerts, certs);
-            } else {
+            if (!resp.success) {
                 if (resp.error) {
                     pivError.show(resp.error)
                 } else {

--- a/ykman-gui/qml/PivView.qml
+++ b/ykman-gui/qml/PivView.qml
@@ -2,6 +2,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.2
 import QtQuick.Controls.Material 2.2
+import "utils.js" as Utils
 
 ColumnLayout {
     id: pivView
@@ -16,21 +17,12 @@ ColumnLayout {
         isBusy = true
         yubiKey.pivListCertificates(function (resp) {
             if (resp.success) {
+                var certs = {};
                 for (var i = 0; i < resp.certs.length; i++) {
                     var cert = resp.certs[i]
-                    if (cert.slot === 'AUTHENTICATION') {
-                        yubiKey.authenticationCert = cert
-                    }
-                    if (cert.slot === 'SIGNATURE') {
-                        yubiKey.signatureCert = cert
-                    }
-                    if (cert.slot === 'KEY_MANAGEMENT') {
-                        yubiKey.keyManagementCert = cert
-                    }
-                    if (cert.slot === 'CARD_AUTH') {
-                        yubiKey.cardAuthenticationCert = cert
-                    }
+                    certs[cert.slot] = cert;
                 }
+                yubiKey.pivCerts = Utils.extend(yubiKey.pivCerts, certs);
             } else {
                 if (resp.error) {
                     pivError.show(resp.error)

--- a/ykman-gui/qml/PivView.qml
+++ b/ykman-gui/qml/PivView.qml
@@ -53,7 +53,7 @@ ColumnLayout {
 
             BreadCrumbRow {
                 items: [{
-                        text: qsTr("PIV")
+                        "text": qsTr("PIV")
                     }]
             }
             RowLayout {

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -427,14 +427,7 @@ Python {
     function pivListCertificates(cb) {
         doCall('yubikey.controller.piv_list_certificates', [], function (resp) {
             if (resp.success) {
-                var certs = {
-
-                }
-                for (var i = 0; i < resp.certs.length; i++) {
-                    var cert = resp.certs[i]
-                    certs[cert.slot] = cert
-                }
-                pivCerts = Utils.extend(yubiKey.pivCerts, certs)
+                pivCerts = Utils.indexBy(resp.certs, "slot")
             }
             cb(resp)
         })

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -29,10 +29,27 @@ Python {
     property var piv
     property bool pivPukBlocked: false
 
-    property var authenticationCert
-    property var signatureCert
-    property var keyManagementCert
-    property var cardAuthenticationCert
+    property var pivSlots: [{
+            "id": "AUTHENTICATION",
+            "name": qsTr("Authentication"),
+            "hex": "9a"
+        }, {
+            "id": "SIGNATURE",
+            "name": qsTr("Digital Signature"),
+            "hex": "9c"
+        }, {
+            "id": "KEY_MANAGEMENT",
+            "name": qsTr("Key Management"),
+            "hex": "9d"
+        }, {
+            "id": "CARD_AUTH",
+            "name": qsTr("Card Authentication"),
+            "hex": "9e"
+        }]
+
+    property var pivCerts: ({
+
+                            })
 
     signal enableLogging(string logLevel, string logFile)
     signal disableLogging
@@ -203,11 +220,10 @@ Python {
     }
 
     function numberOfPivCertificates() {
-        function hasCert(cert) {
-            return !!cert
+        function hasCert(slotObj) {
+            return !!pivCerts[slotObj.id]
         }
-        return [yubiKey.authenticationCert, yubiKey.signatureCert, yubiKey.keyManagementCert, yubiKey.cardAuthenticationCert].filter(
-                    hasCert).length
+        return pivSlots.filter(hasCert).length
     }
 
     function refresh(doneCallback) {

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -424,7 +424,17 @@ Python {
     }
 
     function pivListCertificates(cb) {
-        doCall('yubikey.controller.piv_list_certificates', [], cb)
+        doCall('yubikey.controller.piv_list_certificates', [], function(resp) {
+            if (resp.success) {
+                var certs = {};
+                for (var i = 0; i < resp.certs.length; i++) {
+                    var cert = resp.certs[i]
+                    certs[cert.slot] = cert;
+                }
+                pivCerts = Utils.extend(yubiKey.pivCerts, certs);
+            }
+            cb(resp)
+        })
     }
 
     function pivReadCertificate(slot, cb) {

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -269,6 +269,7 @@ Python {
         }
     }
 
+
     /**
      * Transform a `callback` into one that will first call `refreshPiv` and then
      * itself when `refresh` is done.
@@ -424,14 +425,16 @@ Python {
     }
 
     function pivListCertificates(cb) {
-        doCall('yubikey.controller.piv_list_certificates', [], function(resp) {
+        doCall('yubikey.controller.piv_list_certificates', [], function (resp) {
             if (resp.success) {
-                var certs = {};
+                var certs = {
+
+                }
                 for (var i = 0; i < resp.certs.length; i++) {
                     var cert = resp.certs[i]
-                    certs[cert.slot] = cert;
+                    certs[cert.slot] = cert
                 }
-                pivCerts = Utils.extend(yubiKey.pivCerts, certs);
+                pivCerts = Utils.extend(yubiKey.pivCerts, certs)
             }
             cb(resp)
         })

--- a/ykman-gui/qml/utils.js
+++ b/ykman-gui/qml/utils.js
@@ -103,6 +103,26 @@ function extend(objA, objB) {
 }
 
 /**
+ * Build an object from `arr` by using each item's `name` property as the key
+ *
+ * @param arr an array of objects
+ * @param name a property name
+ *
+ * @return a new object with the items in `arr` as the values, where the key
+ * for each value is `item[name]`. If the `item[name]`s are not unique, the
+ * last occurrence overwrites the others.
+ */
+function indexBy(arr, name) {
+    return arr.reduce(
+        function(result, next) {
+            result[next[name]] = next
+            return result
+        },
+        {}
+    )
+}
+
+/**
  * @param lst a QML basic type `list` value
  * @return the `lst` converted to a JavaScript Array value
  */


### PR DESCRIPTION
This lets us parameterize access by the slot ID (`AUTHENTICATION` etc).

The first draft had `pivSlots` and `pivCerts` merged into one object structure, but I split this into a stateless `pivSlots` array and a stateful `pivCerts` object so that `pivSlots` can provide a clearly defined iteration order,