### PR TITLE
Extract centralized error popup logic

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -450,7 +450,7 @@ class Controller(object):
             except WrongPin as e:
                 return {
                     'success': False,
-                    'error': 'wrong pin',
+                    'error': 'wrong_pin',
                     'tries_left': e.tries_left,
                 }
 
@@ -458,7 +458,7 @@ class Controller(object):
                 if e.sw == SW.INCORRECT_PARAMETERS:
                     return {
                         'success': False,
-                        'error': 'incorrect parameters',
+                        'error': 'incorrect_parameters',
                     }
 
                 tries_left = piv_controller.get_pin_tries()
@@ -494,7 +494,7 @@ class Controller(object):
             except WrongPuk as e:
                 return {
                     'success': False,
-                    'error': 'wrong puk',
+                    'error': 'wrong_puk',
                     'tries_left': e.tries_left,
                 }
 
@@ -567,7 +567,7 @@ class Controller(object):
             except WrongPuk as e:
                 return {
                     'success': False,
-                    'error': 'wrong puk',
+                    'error': 'wrong_puk',
                     'tries_left': e.tries_left,
                 }
 

--- a/ykman-gui/qml/PivCertificateInfo.qml
+++ b/ykman-gui/qml/PivCertificateInfo.qml
@@ -17,11 +17,11 @@ ColumnLayout {
             if (resp.success) {
                 certificate = resp.cert
             } else {
-                if (resp.error) {
-                    pivError.show(resp.error)
-                } else {
-                    pivError.show('Failed to read certificate')
-                }
+                pivError.showResponseError(
+                    resp,
+                    qsTr('Failed to read certificate. Error message: %1'),
+                    qsTr('Failed to read certificate.')
+                )
             }
         })
     }

--- a/ykman-gui/qml/PivChangePinView.qml
+++ b/ykman-gui/qml/PivChangePinView.qml
@@ -23,28 +23,23 @@ ChangePinView {
                 pivSuccessPopup.open()
                 views.pop()
             } else {
-                if (resp.error === 'wrong pin') {
+                pivError.showResponseError(
+                    resp,
+                    qsTr("PIN change failed for an unknown reason. Error message: %1"),
+                    qsTr("PIN change failed for an unknown reason."),
+                    {
+                        wrong_pin: qsTr("Wrong current PIN. Tries remaining: %1").arg(resp.tries_left),
+                        blocked: qsTr("PIN is blocked. Use the PUK to unlock it, or reset the PIV application."),
+                        incorrect_parameters: qsTr("Invalid PIN format. PIN must be %1 to %2 characters.").arg(minLength).arg(maxLength),
+                    }
+                )
+
+                if (resp.error === 'wrong_pin') {
                     clearCurrentPinInput()
-                    pivError.show(
-                                qsTr("Wrong current PIN. Tries remaining: %1").arg(
-                                    resp.tries_left))
                 } else if (resp.error === 'blocked') {
-                    pivError.show(
-                                qsTr("PIN is blocked. Use the PUK to unlock it, or reset the PIV application."))
                     views.pop()
-                } else if (resp.error === 'incorrect parameters') {
+                } else if (resp.error === 'incorrect_parameters') {
                     clearNewPinInputs()
-                    pivError.show(
-                                qsTr("Invalid PIN format. PIN must be %1 to %2 characters.").arg(
-                                    minLength).arg(maxLength))
-                } else if (resp.message) {
-                    pivError.show(
-                                qsTr("PIN change failed for an unknown reason. Error message: %1").arg(
-                                    resp.message))
-                } else {
-                    pivError.show(
-                                qsTr(
-                                    "PIN change failed for an unknown reason."))
                 }
             }
         })

--- a/ykman-gui/qml/PivChangePukView.qml
+++ b/ykman-gui/qml/PivChangePukView.qml
@@ -24,22 +24,21 @@ ChangePinView {
                 pivSuccessPopup.open()
                 views.pop()
             } else {
+                pivError.showResponseError(
+                    resp,
+                    qsTr("PUK change failed for an unknown reason. Error message: %1"),
+                    qsTr("PUK change failed for an unknown reason."),
+                    {
+                        blocked: qsTr("PUK is blocked."),
+                        wrong_puk: qsTr("Wrong current PUK. Tries remaning: %1")
+                            .arg(resp.tries_left),
+                    }
+                )
+
                 if (resp.error === 'blocked') {
-                    pivError.show(qsTr("PUK is blocked."))
                     views.pop()
-                } else if (resp.error === 'wrong puk') {
+                } else if (resp.error === 'wrong_puk') {
                     clearCurrentPinInput()
-                    pivError.show(
-                                qsTr("Wrong current PUK. Tries remaning: %1").arg(
-                                    resp.tries_left))
-                } else if (resp.message) {
-                    pivError.show(
-                                qsTr("PUK change failed for an unknown reason. Error message: %1").arg(
-                                    resp.message))
-                } else {
-                    pivError.show(
-                                qsTr(
-                                    "PUK change failed for an unknown reason."))
                 }
             }
         })

--- a/ykman-gui/qml/PivGeneralErrorPopup.qml
+++ b/ykman-gui/qml/PivGeneralErrorPopup.qml
@@ -9,31 +9,31 @@ InlinePopup {
 
     function getDefaultMessage(resp) {
         switch (resp.error) {
-        case 'wrong_key':
-            return qsTr("Wrong management key.")
+        case 'bad_format':
+            return qsTr('Management key must be exactly %1 hexadecimal characters.'.arg(constants.pivManagementKeyHexLength))
+
+        case 'blocked':
+            return qsTr('PIN is blocked.')
 
         case 'key_required':
             return qsTr("Management key is required.")
+
+        case 'new_key_bad_length':
+        case 'new_key_bad_hex':
+            return qsTr('New management key must be exactly %1 hexadecimal characters.')
+                .arg(constants.pivManagementKeyHexLength)
+
+        case 'pin_required':
+            return qsTr("PIN is required.")
+
+        case 'wrong_key':
+            return qsTr("Wrong management key.")
 
         case 'wrong_pin':
             return qsTr('Wrong PIN, %1 tries left.'.arg(resp.tries_left))
 
         case 'wrong_puk':
             return qsTr("Wrong PUK. Tries remaning: %1".arg(resp.tries_left))
-
-        case 'blocked':
-            return qsTr('PIN is blocked.')
-
-        case 'bad_format':
-            return qsTr('Management key must be exactly %1 hexadecimal characters.'.arg(constants.pivManagementKeyHexLength))
-
-        case 'pin_required':
-            return qsTr("PIN is required.")
-
-        case 'new_key_bad_length':
-        case 'new_key_bad_hex':
-            return qsTr('New management key must be exactly %1 hexadecimal characters.')
-                .arg(constants.pivManagementKeyHexLength)
         }
     }
 

--- a/ykman-gui/qml/PivGeneralErrorPopup.qml
+++ b/ykman-gui/qml/PivGeneralErrorPopup.qml
@@ -12,6 +12,37 @@ InlinePopup {
         open()
     }
 
+    function showResponseError(resp, genericErrorMessageTemplate, unknownErrorMessage) {
+        if (!resp.success) {
+            if (resp.error === 'wrong_key') {
+                show(qsTr("Wrong management key."))
+
+            } else if (resp.error === 'key_required') {
+                show(qsTr("Management key is required."))
+
+            } else if (resp.error === 'wrong_pin') {
+                show(qsTr('Wrong PIN, %1 tries left.').arg(resp.tries_left))
+
+            } else if (resp.error === 'blocked') {
+                show(qsTr('PIN is blocked.'))
+
+            } else if (resp.error === 'bad_format') {
+                show(qsTr('Bad management key format.'))
+
+            } else if (resp.error === 'pin_required') {
+                show(qsTr("PIN is required."))
+
+            } else if (genericErrorMessageTemplate && resp.message) {
+                console.log('PIV unmapped error:', resp.error, resp.message)
+                show(genericErrorMessageTemplate.arg(resp.message))
+
+            } else if (unknownErrorMessage) {
+                console.log('PIV error:', resp.error)
+                show(unknownErrorMessage)
+            }
+        }
+    }
+
     ColumnLayout {
         width: parent.width
 

--- a/ykman-gui/qml/PivGeneralErrorPopup.qml
+++ b/ykman-gui/qml/PivGeneralErrorPopup.qml
@@ -12,9 +12,12 @@ InlinePopup {
         open()
     }
 
-    function showResponseError(resp, genericErrorMessageTemplate, unknownErrorMessage) {
+    function showResponseError(resp, genericErrorMessageTemplate, unknownErrorMessage, messages) {
         if (!resp.success) {
-            if (resp.error === 'wrong_key') {
+            if (messages && messages[resp.error]) {
+                show(messages[resp.error])
+
+            } else if (resp.error === 'wrong_key') {
                 show(qsTr("Wrong management key."))
 
             } else if (resp.error === 'key_required') {
@@ -23,14 +26,21 @@ InlinePopup {
             } else if (resp.error === 'wrong_pin') {
                 show(qsTr('Wrong PIN, %1 tries left.').arg(resp.tries_left))
 
+            } else if (resp.error === 'wrong_puk') {
+                show(qsTr("Wrong PUK. Tries remaning: %1").arg(resp.tries_left))
+
             } else if (resp.error === 'blocked') {
                 show(qsTr('PIN is blocked.'))
 
             } else if (resp.error === 'bad_format') {
-                show(qsTr('Bad management key format.'))
+                show(qsTr('Management key must be exactly %1 hexadecimal characters.').arg(constants.pivManagementKeyHexLength))
 
             } else if (resp.error === 'pin_required') {
                 show(qsTr("PIN is required."))
+
+            } else if (resp.error === 'new_key_bad_length' || resp.error === 'new_key_bad_hex') {
+                show(qsTr('New management key must be exactly %1 hexadecimal characters.')
+                    .arg(constants.pivManagementKeyHexLength))
 
             } else if (genericErrorMessageTemplate && resp.message) {
                 console.log('PIV unmapped error:', resp.error, resp.message)

--- a/ykman-gui/qml/PivGeneralErrorPopup.qml
+++ b/ykman-gui/qml/PivGeneralErrorPopup.qml
@@ -16,39 +16,43 @@ InlinePopup {
         if (!resp.success) {
             if (messages && messages[resp.error]) {
                 show(messages[resp.error])
+            } else {
+                switch (resp.error) {
+                case 'wrong_key':
+                    return show(qsTr("Wrong management key."))
 
-            } else if (resp.error === 'wrong_key') {
-                show(qsTr("Wrong management key."))
+                case 'key_required':
+                    return show(qsTr("Management key is required."))
 
-            } else if (resp.error === 'key_required') {
-                show(qsTr("Management key is required."))
+                case 'wrong_pin':
+                    return show(qsTr('Wrong PIN, %1 tries left.').arg(resp.tries_left))
 
-            } else if (resp.error === 'wrong_pin') {
-                show(qsTr('Wrong PIN, %1 tries left.').arg(resp.tries_left))
+                case 'wrong_puk':
+                    return show(qsTr("Wrong PUK. Tries remaning: %1").arg(resp.tries_left))
 
-            } else if (resp.error === 'wrong_puk') {
-                show(qsTr("Wrong PUK. Tries remaning: %1").arg(resp.tries_left))
+                case 'blocked':
+                    return show(qsTr('PIN is blocked.'))
 
-            } else if (resp.error === 'blocked') {
-                show(qsTr('PIN is blocked.'))
+                case 'bad_format':
+                    return show(qsTr('Management key must be exactly %1 hexadecimal characters.').arg(constants.pivManagementKeyHexLength))
 
-            } else if (resp.error === 'bad_format') {
-                show(qsTr('Management key must be exactly %1 hexadecimal characters.').arg(constants.pivManagementKeyHexLength))
+                case 'pin_required':
+                    return show(qsTr("PIN is required."))
 
-            } else if (resp.error === 'pin_required') {
-                show(qsTr("PIN is required."))
+                case 'new_key_bad_length':
+                case 'new_key_bad_hex':
+                    return show(qsTr('New management key must be exactly %1 hexadecimal characters.')
+                        .arg(constants.pivManagementKeyHexLength))
 
-            } else if (resp.error === 'new_key_bad_length' || resp.error === 'new_key_bad_hex') {
-                show(qsTr('New management key must be exactly %1 hexadecimal characters.')
-                    .arg(constants.pivManagementKeyHexLength))
+                default:
+                    console.log('PIV unmapped error:', resp.error, resp.message)
 
-            } else if (genericErrorMessageTemplate && resp.message) {
-                console.log('PIV unmapped error:', resp.error, resp.message)
-                show(genericErrorMessageTemplate.arg(resp.message))
-
-            } else if (unknownErrorMessage) {
-                console.log('PIV error:', resp.error)
-                show(unknownErrorMessage)
+                    if (genericErrorMessageTemplate && resp.message) {
+                        show(genericErrorMessageTemplate.arg(resp.message))
+                    } else if (unknownErrorMessage) {
+                        show(unknownErrorMessage)
+                    }
+                }
             }
         }
     }

--- a/ykman-gui/qml/PivGeneralErrorPopup.qml
+++ b/ykman-gui/qml/PivGeneralErrorPopup.qml
@@ -7,6 +7,36 @@ InlinePopup {
 
     standardButtons: Dialog.Ok
 
+    function getDefaultMessage(resp) {
+        switch (resp.error) {
+        case 'wrong_key':
+            return qsTr("Wrong management key.")
+
+        case 'key_required':
+            return qsTr("Management key is required.")
+
+        case 'wrong_pin':
+            return qsTr('Wrong PIN, %1 tries left.'.arg(resp.tries_left))
+
+        case 'wrong_puk':
+            return qsTr("Wrong PUK. Tries remaning: %1".arg(resp.tries_left))
+
+        case 'blocked':
+            return qsTr('PIN is blocked.')
+
+        case 'bad_format':
+            return qsTr('Management key must be exactly %1 hexadecimal characters.'.arg(constants.pivManagementKeyHexLength))
+
+        case 'pin_required':
+            return qsTr("PIN is required.")
+
+        case 'new_key_bad_length':
+        case 'new_key_bad_hex':
+            return qsTr('New management key must be exactly %1 hexadecimal characters.')
+                .arg(constants.pivManagementKeyHexLength)
+        }
+    }
+
     function show(message) {
         error = message
         open()
@@ -17,34 +47,10 @@ InlinePopup {
             if (messages && messages[resp.error]) {
                 show(messages[resp.error])
             } else {
-                switch (resp.error) {
-                case 'wrong_key':
-                    return show(qsTr("Wrong management key."))
-
-                case 'key_required':
-                    return show(qsTr("Management key is required."))
-
-                case 'wrong_pin':
-                    return show(qsTr('Wrong PIN, %1 tries left.').arg(resp.tries_left))
-
-                case 'wrong_puk':
-                    return show(qsTr("Wrong PUK. Tries remaning: %1").arg(resp.tries_left))
-
-                case 'blocked':
-                    return show(qsTr('PIN is blocked.'))
-
-                case 'bad_format':
-                    return show(qsTr('Management key must be exactly %1 hexadecimal characters.').arg(constants.pivManagementKeyHexLength))
-
-                case 'pin_required':
-                    return show(qsTr("PIN is required."))
-
-                case 'new_key_bad_length':
-                case 'new_key_bad_hex':
-                    return show(qsTr('New management key must be exactly %1 hexadecimal characters.')
-                        .arg(constants.pivManagementKeyHexLength))
-
-                default:
+                var defaultMessage = getDefaultMessage(resp)
+                if (defaultMessage) {
+                    show(defaultMessage)
+                } else {
                     console.log('PIV unmapped error:', resp.error, resp.message)
 
                     if (genericErrorMessageTemplate && resp.message) {

--- a/ykman-gui/qml/PivResetView.qml
+++ b/ykman-gui/qml/PivResetView.qml
@@ -15,8 +15,11 @@ ColumnLayout {
                 pivSuccessPopup.open()
                 views.pop()
             } else {
-                pivGeneralError.error = resp.error
-                pivGeneralError.open()
+                pivError.showResponseError(
+                    resp,
+                    qsTr("Reset failed for an unknown reason. Error message: %1"),
+                    qsTr("Reset failed for an unknown reason.")
+                )
             }
         })
     }
@@ -24,10 +27,6 @@ ColumnLayout {
     PivResetConfirmPopup {
         id: pivResetConfirmationPopup
         onAccepted: resetPiv()
-    }
-
-    PivGeneralErrorPopup {
-        id: pivGeneralError
     }
 
     BusyIndicator {

--- a/ykman-gui/qml/PivSetManagementKeyView.qml
+++ b/ykman-gui/qml/PivSetManagementKeyView.qml
@@ -60,43 +60,35 @@ ColumnLayout {
                         pivSuccessPopup.open()
                         views.pivPinManagement()
 
-                    } else if (resp.error === 'bad_format') {
-                        pivError.show(qsTr(
-                            "Current management key must be exactly %1 hexadecimal characters.")
-                                .arg(constants.pivManagementKeyHexLength))
-
-                    } else if (resp.error === 'new_key_bad_length' || resp.error === 'new_key_bad_hex') {
-                        pivError.show(qsTr(
-                            "New management key must be exactly %1 hexadecimal characters.")
-                                .arg(constants.pivManagementKeyHexLength))
-
-                    } else if (resp.error === 'wrong_key') {
-                        clearDefaultManagementKey()
-                        pivError.show(qsTr("Wrong current management key."))
-
-                    } else if (resp.error === 'key_required') {
-                        pivError.show(qsTr("Please enter the current management key."))
-
-                    } else if (resp.error === 'wrong_pin') {
-                        pivError.show(qsTr('Wrong PIN, %1 tries left.').arg(resp.tries_left))
-
-                    } else if (resp.error === 'blocked') {
-                        pivError.show(qsTr('PIN is blocked.'))
-                        if (hasProtectedKey) {
-                            views.pivPinManagement()
-                        } else {
-                            views.pop()
-                        }
-
-                    } else if (resp.error === 'pin_required') {
-                        pivError.show(qsTr("Please enter the PIN."))
-
-                    } else if (resp.message) {
-                        pivError.show(resp.message)
-
                     } else {
-                        console.log('Unknown failure:', resp.error)
-                        pivError.show(qsTr('Unknown failure.'))
+                        var badKeyFormat = qsTr("New management key must be exactly %1 hexadecimal characters.")
+                            .arg(constants.pivManagementKeyHexLength)
+
+                        pivError.showResponseError(
+                            resp,
+                            qsTr('Management key change failed. Error message: %1'),
+                            qsTr('Management key change failed for an unknown reason.'),
+                            {
+                                bad_format: qsTr("Current management key must be exactly %1 hexadecimal characters.")
+                                    .arg(constants.pivManagementKeyHexLength),
+                                key_required: qsTr("Please enter the current management key."),
+                                new_key_bad_hex: badKeyFormat,
+                                new_key_bad_length: badKeyFormat,
+                                pin_required: qsTr("Please enter the PIN."),
+                                wrong_key: qsTr("Wrong current management key."),
+                            }
+                        )
+
+                        if (resp.error === 'wrong_key') {
+                            clearDefaultManagementKey()
+
+                        } else if (resp.error === 'blocked') {
+                            if (hasProtectedKey) {
+                                views.pivPinManagement()
+                            } else {
+                                views.pop()
+                            }
+                        }
                     }
                 },
                 pin,

--- a/ykman-gui/qml/PivUnblockPinView.qml
+++ b/ykman-gui/qml/PivUnblockPinView.qml
@@ -27,20 +27,19 @@ ChangePinView {
                 pivSuccessPopup.open()
                 views.pop()
             } else {
+                pivError.showResponseError(
+                    resp,
+                    qsTr("PIN unblock failed for an unknown reason. Error message: %1").arg(resp.message),
+                    qsTr("PIN unblock failed for an unknown reason."),
+                    {
+                        blocked: qsTr("PUK is blocked."),
+                    }
+                )
+
                 if (resp.error === 'blocked') {
-                    pivError.show(qsTr("PUK is blocked."))
                     views.pop()
-                } else if (resp.error === 'wrong puk') {
+                } else if (resp.error === 'wrong_puk') {
                     clearCurrentPinInput()
-                    pivError.show(qsTr("Wrong PUK. Tries remaning: %1").arg(
-                                      resp.tries_left))
-                } else if (resp.message) {
-                    pivError.show(
-                                qsTr("PIN unblock failed for an unknown reason. Error message: %1").arg(
-                                    resp.message))
-                } else {
-                    pivError.show(
-                                qsTr("PIN unblock failed for an unknown reason."))
                 }
             }
         })

--- a/ykman-gui/qml/PivView.qml
+++ b/ykman-gui/qml/PivView.qml
@@ -17,11 +17,11 @@ ColumnLayout {
         isBusy = true
         yubiKey.pivListCertificates(function (resp) {
             if (!resp.success) {
-                if (resp.error) {
-                    pivError.show(resp.error)
-                } else {
-                    pivError.show('Failed to list certificates')
-                }
+                pivError.showResponseError(
+                    resp,
+                    qsTr('Failed to list certificates. Error message: %1'),
+                    qsTr('Failed to list certificates.')
+                )
             }
             isBusy = false
         })


### PR DESCRIPTION
This allows us to specify centrally managed but overridable default behaviours for each kind of `resp.error` returned from the Python layer.