### PR TITLE
Merge pivListCertificates and pivReadCertificate into refreshPiv

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -414,20 +414,6 @@ class Controller(object):
             logger.error('Failed to reset PIV application', exc_info=e)
             return {'success': False, 'error': str(e)}
 
-    def piv_read_certificate(self, slot):
-        try:
-            with self._open_piv() as controller:
-                cert = controller.read_certificate(SLOT[slot])
-                cert = _piv_serialise_cert(SLOT[slot], cert)
-                return {'success': True, 'cert': cert, 'error': None}
-        except APDUError as e:
-            if e.sw == SW.NOT_FOUND:
-                return {'success': True, 'cert': None, 'error': None}
-            raise
-        except Exception as e:
-            logger.error('Failed to read PIV certificate', exc_info=e)
-            return {'success': False, 'error': str(e)}
-
     def _piv_list_certificates(self, controller):
         return {
             SLOT(slot).name: _piv_serialise_cert(slot, cert) for slot, cert in controller.list_certificates().items()  # noqa: E501

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -597,7 +597,7 @@ class Controller(object):
                         'success': False,
                         'error_id': 'wrong_mgm_key'
                     }
-                except BadFormat as e:
+                except BadFormat:
                     return {
                         'success': False,
                         'error_id': 'mgm_key_bad_format',

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -592,7 +592,7 @@ class Controller(object):
 
                 try:
                     piv_controller.authenticate(mgm_key_bytes)
-                except AuthenticationFailed as e:
+                except AuthenticationFailed:
                     return {
                         'success': False,
                         'error_id': 'wrong_mgm_key'

--- a/ykman-gui/qml/PivCertificateInfo.qml
+++ b/ykman-gui/qml/PivCertificateInfo.qml
@@ -13,7 +13,7 @@ ColumnLayout {
 
     onVisibleChanged: visible ? load() : ''
     function load() {
-        yubiKey.refreshPiv()
+        yubiKey.refreshPivData()
     }
 
     Heading2 {

--- a/ykman-gui/qml/PivCertificateInfo.qml
+++ b/ykman-gui/qml/PivCertificateInfo.qml
@@ -13,17 +13,7 @@ ColumnLayout {
 
     onVisibleChanged: visible ? load() : ''
     function load() {
-        yubiKey.pivReadCertificate(slot, function (resp) {
-            if (resp.success) {
-                certificate = resp.cert
-            } else {
-                if (resp.error) {
-                    pivError.show(resp.error)
-                } else {
-                    pivError.show('Failed to read certificate')
-                }
-            }
-        })
+        yubiKey.refreshPiv(function () {})
     }
 
     Heading2 {

--- a/ykman-gui/qml/PivCertificateInfo.qml
+++ b/ykman-gui/qml/PivCertificateInfo.qml
@@ -13,7 +13,7 @@ ColumnLayout {
 
     onVisibleChanged: visible ? load() : ''
     function load() {
-        yubiKey.refreshPiv(function () {})
+        yubiKey.refreshPiv()
     }
 
     Heading2 {

--- a/ykman-gui/qml/PivPinManagementView.qml
+++ b/ykman-gui/qml/PivPinManagementView.qml
@@ -20,7 +20,7 @@ ColumnLayout {
 
     function load() {
         isBusy = true
-        yubiKey.refreshPiv(function () {
+        yubiKey.refreshPivData(function () {
             isBusy = false
         })
     }

--- a/ykman-gui/qml/PivView.qml
+++ b/ykman-gui/qml/PivView.qml
@@ -15,14 +15,7 @@ ColumnLayout {
 
     function load() {
         isBusy = true
-        yubiKey.pivListCertificates(function (resp) {
-            if (!resp.success) {
-                if (resp.error) {
-                    pivError.show(resp.error)
-                } else {
-                    pivError.show('Failed to list certificates')
-                }
-            }
+        yubiKey.refreshPiv(function () {
             isBusy = false
         })
     }

--- a/ykman-gui/qml/PivView.qml
+++ b/ykman-gui/qml/PivView.qml
@@ -15,7 +15,7 @@ ColumnLayout {
 
     function load() {
         isBusy = true
-        yubiKey.refreshPiv(function () {
+        yubiKey.refreshPivData(function () {
             isBusy = false
         })
     }

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -262,7 +262,7 @@ Python {
         })
     }
 
-    function refreshPiv(doneCallback) {
+    function refreshPivData(doneCallback) {
         if (hasDevice) {
             doCall('yubikey.controller.refresh_piv', [], function (pivData) {
                 piv = pivData
@@ -279,22 +279,22 @@ Python {
 
 
     /**
-     * Transform a `callback` into one that will first call `refreshPiv` and then
-     * itself when `refresh` is done.
+     * Transform a `callback` into one that will first call `refreshPivData`
+     * and then itself when `refresh` is done.
      *
      * The arguments and `this` context of the call to the `callback` are
      * preseved.
      *
      * @param callback a function
      *
-     * @return a function which will call `refreshPiv()` and delay the execution of
-     *          the `callback` until the `refreshPiv()` is done.
+     * @return a function which will call `refreshPivData()` and delay the
+     *      execution of the `callback` until the `refreshPivData()` is done.
      */
     function _refreshPivBefore(callback) {
         return function (/* ...arguments */ ) {
             var callbackThis = this
             var callbackArguments = arguments
-            refreshPiv(function () {
+            refreshPivData(function () {
                 callback.apply(callbackThis, callbackArguments)
             })
         }
@@ -403,7 +403,7 @@ Python {
                   [pin, currentMgmKey, newKey, storeOnDevice],
                   function (result) {
                       touchPromptTimer.stop()
-                      refreshPiv(function () {
+                      refreshPivData(function () {
                           cb(result)
                       })
                   })

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -425,8 +425,4 @@ Python {
                       cb(resp)
                   })
     }
-
-    function pivReadCertificate(slot, cb) {
-        doPivCall('yubikey.controller.piv_read_certificate', [slot], cb)
-    }
 }

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -266,10 +266,14 @@ Python {
         if (hasDevice) {
             doCall('yubikey.controller.refresh_piv', [], function (pivData) {
                 piv = pivData
-                doneCallback()
+                if (doneCallback) {
+                    doneCallback()
+                }
             })
         } else {
-            doneCallback()
+            if (doneCallback) {
+                doneCallback()
+            }
         }
     }
 

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -266,10 +266,17 @@ Python {
         if (hasDevice) {
             doCall('yubikey.controller.refresh_piv', [], function (pivData) {
                 piv = pivData
-                doneCallback()
+
+                doCall('yubikey.controller.piv_list_certificates', [],
+                    function (resp) {
+                        if (resp.success) {
+                            pivCerts = Utils.indexBy(resp.certs, "slot")
+                        }
+                        doneCallback(resp)
+                    })
             })
         } else {
-            doneCallback()
+            doneCallback({})
         }
     }
 
@@ -427,13 +434,7 @@ Python {
     }
 
     function pivListCertificates(cb) {
-        doPivCall('yubikey.controller.piv_list_certificates', [],
-                  function (resp) {
-                      if (resp.success) {
-                          pivCerts = Utils.indexBy(resp.certs, "slot")
-                      }
-                      cb(resp)
-                  })
+        refreshPiv(cb)
     }
 
     function pivReadCertificate(slot, cb) {

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -47,9 +47,9 @@ Python {
             "hex": "9e"
         }]
 
-    property var pivCerts: ({
+    readonly property var pivCerts: piv && piv.certs || {
 
-                            })
+                                    }
 
     signal enableLogging(string logLevel, string logFile)
     signal disableLogging
@@ -266,17 +266,10 @@ Python {
         if (hasDevice) {
             doCall('yubikey.controller.refresh_piv', [], function (pivData) {
                 piv = pivData
-
-                doCall('yubikey.controller.piv_list_certificates', [],
-                    function (resp) {
-                        if (resp.success) {
-                            pivCerts = Utils.indexBy(resp.certs, "slot")
-                        }
-                        doneCallback(resp)
-                    })
+                doneCallback()
             })
         } else {
-            doneCallback({})
+            doneCallback()
         }
     }
 
@@ -431,10 +424,6 @@ Python {
                       }
                       cb(resp)
                   })
-    }
-
-    function pivListCertificates(cb) {
-        refreshPiv(cb)
     }
 
     function pivReadCertificate(slot, cb) {


### PR DESCRIPTION
This causes some error handling to be removed, since we don't have any good facilities for capturing errors from `refreshPiv` right now.