### PR TITLE
Hard-code CalendarWidget to en_US locale with no weekday labels

### DIFF
--- a/ykman-gui/qml/CalendarWidget.qml
+++ b/ykman-gui/qml/CalendarWidget.qml
@@ -68,32 +68,13 @@ ListView {
             }
         }
 
-        GridLayout {
-            columns: 2
+        MonthGrid {
+            id: grid
+            month: model.month
+            year: model.year
+            Layout.fillWidth: true
 
-            DayOfWeekRow {
-                locale: grid.locale
-
-                Layout.column: 1
-                Layout.fillWidth: true
-            }
-
-            WeekNumberColumn {
-                month: grid.month
-                year: grid.year
-                locale: grid.locale
-
-                Layout.fillHeight: true
-            }
-
-            MonthGrid {
-                id: grid
-                month: model.month
-                year: model.year
-                Layout.fillWidth: true
-
-                onClicked: dateClicked(date)
-            }
+            onClicked: dateClicked(date)
         }
     }
 }

--- a/ykman-gui/qml/CalendarWidget.qml
+++ b/ykman-gui/qml/CalendarWidget.qml
@@ -72,6 +72,7 @@ ListView {
             id: grid
             month: model.month
             year: model.year
+            locale: Qt.locale('en_US')
             Layout.fillWidth: true
 
             onClicked: dateClicked(date)


### PR DESCRIPTION
Putting this in its own PR because I'm not completely convinced this is a good idea...

- Advantage: consistent English language in the GUI
- Disadvantage: start-of-week weekday confusion

I personally think the disadvantage outweighs the advantage. I don't find it jarring that this one widget renders in Swedish for me - on the contrary, I find it to be a good thing.

On the other hand: right now this is only used for the cert expiration date, where it probably won't matter much if someone gets the expiry date wrong by one day.

I still think we should not do this, but I won't oppose going forward with it.