### PR TITLE
Put NextButton icon on the right

### DIFF
--- a/ykman-gui/qml/CustomButton.qml
+++ b/ykman-gui/qml/CustomButton.qml
@@ -9,7 +9,9 @@ Button {
 
     property string iconSource
     property string toolTipText
+
     property string foregroundColor: getForegroundColor()
+    property bool iconOnRight: false
 
     font.capitalization: Font.MixedCase
     font.family: constants.fontFamily
@@ -37,8 +39,8 @@ Button {
     // which was introduced in Qt 5.10.
     contentItem: RowLayout {
         Image {
-            visible: iconSource !== null
-            id: icon
+            visible: iconSource !== null && !iconOnRight
+            id: iconLeft
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             fillMode: Image.PreserveAspectFit
             sourceSize.height: 16
@@ -46,8 +48,8 @@ Button {
             source: iconSource
 
             ColorOverlay {
-                anchors.fill: icon
-                source: icon
+                anchors.fill: iconLeft
+                source: iconLeft
                 color: foregroundColor
             }
         }
@@ -55,6 +57,21 @@ Button {
             visible: !!button.text
             text: button.text
             font: button.font
+        }
+        Image {
+            visible: iconSource !== null && iconOnRight
+            id: iconRight
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            fillMode: Image.PreserveAspectFit
+            sourceSize.height: 16
+            sourceSize.width: 16
+            source: iconSource
+
+            ColorOverlay {
+                anchors.fill: iconRight
+                source: iconRight
+                color: foregroundColor
+            }
         }
     }
 }

--- a/ykman-gui/qml/NextButton.qml
+++ b/ykman-gui/qml/NextButton.qml
@@ -1,5 +1,6 @@
 CustomButton {
     text: qsTr("Next")
     highlighted: true
+    iconOnRight: true
     iconSource: "../images/next.svg"
 }


### PR DESCRIPTION
NextButton currently only exists in the `piv` branch, not `master`, but this will affect all uses of `NextButton` including those added to `OtpConfigureSlotView`.

This is mostly unrelated to the `piv-cert-generate` branch, but I'm targeting that as the merge base to avoid a merge conflict that appeared when I tried to rebase this to the `piv` branch.