### PR TITLE
Unify python responses

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -144,7 +144,7 @@ class Controller(object):
         descriptors = list(get_descriptors())
         if len(descriptors) != 1:
             self._descriptor = None
-            return {'success': False, 'error': 'Multiple devices', 'dev': None}
+            return failure('multiple_devices')
         desc = descriptors[0]
 
         # If we have a cached descriptor
@@ -158,11 +158,7 @@ class Controller(object):
         try:
             with self._open_device() as dev:
                 if not dev:
-                    return {
-                        'success': False,
-                        'error': 'No device',
-                        'dev': None
-                    }
+                    return failure('no_device')
 
                 self._dev_info = {
                         'name': dev.device_name,

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -50,6 +50,8 @@ def catch_error(f):
         except YkpersError as e:
             if e.errno == 3:
                 return failure('write error')
+            if e.errno == 4:
+                return failure('timeout')
 
             logger.error('Uncaught exception', exc_info=e)
             return unknown_failure(e)
@@ -241,13 +243,8 @@ class Controller(object):
         return success({'is_macos': sys.platform == 'darwin'})
 
     def slots_status(self):
-        try:
-            with self._open_otp_controller() as controller:
-                return success({'status': controller.slot_status})
-        except YkpersError as e:
-            if e.errno == 4:
-                return failure('timeout')
-            raise
+        with self._open_otp_controller() as controller:
+            return success({'status': controller.slot_status})
 
     def erase_slot(self, slot):
         with self._open_otp_controller() as controller:

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -266,7 +266,7 @@ class Controller(object):
             return success()
         except YkpersError as e:
             if e.errno == 3:
-                return {'success': False, 'error': 'write error'}
+                return failure('write error')
             raise
 
     def swap_slots(self):

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -370,7 +370,7 @@ class Controller(object):
                 return success()
         except CtapError as e:
             if e.code == CtapError.ERR.INVALID_LENGTH:
-                return {'success': False, 'error': 'too long'}
+                return failure('too long')
             logger.error('Failed to set PIN', exc_info=e)
             raise
         except Exception as e:

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -303,7 +303,7 @@ class Controller(object):
             return success()
         except YkpersError as e:
             if e.errno == 3:
-                return {'success': False, 'error': 'write error'}
+                return failure('write error')
             raise
 
     def program_challenge_response(self, slot, key, touch):

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -384,16 +384,13 @@ class Controller(object):
                 return success()
         except CtapError as e:
             if e.code == CtapError.ERR.INVALID_LENGTH:
-                return {'success': False,
-                        'error': 'too long'}
+                return failure('too long')
             if e.code == CtapError.ERR.PIN_INVALID:
-                return {'success': False,
-                        'error': 'wrong pin'}
+                return failure('wrong pin')
             if e.code == CtapError.ERR.PIN_AUTH_BLOCKED:
-                return {'success': False,
-                        'error': 'currently blocked'}
+                return failure('currently blocked')
             if e.code == CtapError.ERR.PIN_BLOCKED:
-                return {'success': False, 'error': 'blocked'}
+                return failure('blocked')
             logger.error('Failed to set PIN', exc_info=e)
             raise
         except Exception as e:

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -355,16 +355,10 @@ class Controller(object):
                 return success({'retries': controller.get_pin_retries()})
         except CtapError as e:
             if e.code == CtapError.ERR.PIN_AUTH_BLOCKED:
-                return {
-                    'success': False,
-                    'retries': None,
-                    'error': 'PIN authentication is currently blocked. '
-                             'Remove and re-insert the YubiKey.'}
+                return failure('PIN authentication is currently blocked. '
+                               'Remove and re-insert the YubiKey.')
             if e.code == CtapError.ERR.PIN_BLOCKED:
-                return {
-                    'success': False,
-                    'retries': None,
-                    'error': 'PIN is blocked.'}
+                return failure('PIN is blocked.')
         except Exception as e:
             logger.error('Failed to read PIN retries', exc_info=e)
             raise

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -404,9 +404,9 @@ class Controller(object):
                 return success()
         except CtapError as e:
             if e.code == CtapError.ERR.NOT_ALLOWED:
-                return {'success': False, 'error': 'not allowed'}
+                return failure('not allowed')
             if e.code == CtapError.ERR.ACTION_TIMEOUT:
-                return {'success': False, 'error': 'touch timeout'}
+                return failure('touch timeout')
             raise
 
     def piv_reset(self):

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -47,11 +47,8 @@ def catch_error(f):
         try:
             return f(*args, **kwargs)
         except FailedOpeningDeviceException as e:
-            return {
-                'success': False,
-                'error_id': 'open_device_failed',
-                'error_message': str(e),
-            }
+            return failure('open_device_failed')
+
         except Exception as e:
             logger.error('Uncaught exception', exc_info=e)
             return {

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -338,7 +338,7 @@ class Controller(object):
             return success()
         except YkpersError as e:
             if e.errno == 3:
-                return {'success': False, 'error': 'write error'}
+                return failure('write error')
             raise
 
     def fido_has_pin(self):

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -314,7 +314,7 @@ class Controller(object):
             return success()
         except YkpersError as e:
             if e.errno == 3:
-                return {'success': False, 'error': 'write error'}
+                return failure('write error')
             raise
 
     def program_static_password(self, slot, key, keyboard_layout):

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -326,7 +326,7 @@ class Controller(object):
             return success()
         except YkpersError as e:
             if e.errno == 3:
-                return {'success': False, 'error': 'write error'}
+                failure('write error')
             raise
 
     def program_oath_hotp(self, slot, key, digits):

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -252,7 +252,7 @@ class Controller(object):
                 return success({'status': controller.slot_status})
         except YkpersError as e:
             if e.errno == 4:
-                return {'success': False, 'status': None, 'error': 'timeout'}
+                return failure('timeout')
             logger.error('Failed to read slot status', exc_info=e)
             raise
         except Exception as e:

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -276,7 +276,7 @@ class Controller(object):
             return success()
         except YkpersError as e:
             if e.errno == 3:
-                return {'success': False, 'error': 'write error'}
+                return failure('write error')
             raise
 
     def serial_modhex(self):

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -51,11 +51,8 @@ def catch_error(f):
 
         except Exception as e:
             logger.error('Uncaught exception', exc_info=e)
-            return {
-                'success': False,
-                'error_id': None,
-                'error_message': str(e),
-            }
+            return unknown_failure(e)
+
     return wrapped
 
 
@@ -68,6 +65,10 @@ def failure(err_id, result={}):
     result['success'] = False
     result['error_id'] = err_id
     return result
+
+
+def unknown_failure(exception):
+    return failure(None, {'error_message': str(exception)})
 
 
 class OtpContextManager(object):

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -202,8 +202,7 @@ class Controller(object):
                 if lock_code:
                     lock_code = a2b_hex(lock_code)
                     if len(lock_code) != 16:
-                        return {'success': False,
-                                'error': 'Lock code not 16 bytes'}
+                        return failure('lock_code_not_16_bytes')
                 dev.write_config(
                     device_config(
                         usb_enabled=usb_enabled,

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -180,7 +180,7 @@ class Controller(object):
 
         except Exception as e:
             logger.error('Failed to open device', exc_info=e)
-            return {'success': False, 'error': str(e), 'dev': None}
+            raise
 
     def write_config(self, usb_applications, nfc_applications, lock_code):
         usb_enabled = 0x00
@@ -207,7 +207,7 @@ class Controller(object):
                 return {'success': True, 'error': None}
         except Exception as e:
             logger.error('Failed to write config', exc_info=e)
-            return {'success': False, 'error': str(e)}
+            raise
 
     def refresh_piv(self):
         with self._open_piv() as piv_controller:
@@ -232,20 +232,14 @@ class Controller(object):
                 dev.mode = Mode(transports & TRANSPORT.usb_transports())
         except Exception as e:
             logger.error('Failed to set mode', exc_info=e)
-            return str(e)
+            raise
 
     def get_username(self):
-        try:
-            username = getpass.getuser()
-            return {'success': True, 'username': username}
-        except Exception as e:
-            return {'success': False, 'error': str(e)}
+        username = getpass.getuser()
+        return {'success': True, 'username': username}
 
     def is_macos(self):
-        try:
-            return {'success': True, 'is_macos': sys.platform == 'darwin'}
-        except Exception as e:
-            return {'success': False, 'error': str(e)}
+        return {'success': True, 'is_macos': sys.platform == 'darwin'}
 
     def slots_status(self):
         try:
@@ -258,10 +252,10 @@ class Controller(object):
             if e.errno == 4:
                 return {'success': False, 'status': None, 'error': 'timeout'}
             logger.error('Failed to read slot status', exc_info=e)
-            return {'success': False, 'status': None, 'error': str(e)}
+            raise
         except Exception as e:
             logger.error('Failed to read slot status', exc_info=e)
-            return {'success': False, 'status': None, 'error': str(e)}
+            raise
 
     def erase_slot(self, slot):
         try:
@@ -271,9 +265,7 @@ class Controller(object):
         except YkpersError as e:
             if e.errno == 3:
                 return {'success': False, 'error': 'write error'}
-            return {'success': False, 'error': str(e)}
-        except Exception as e:
-            return {'success': False, 'error': str(e)}
+            raise
 
     def swap_slots(self):
         try:
@@ -283,9 +275,7 @@ class Controller(object):
         except YkpersError as e:
             if e.errno == 3:
                 return {'success': False, 'error': 'write error'}
-            return {'success': False, 'error': str(e)}
-        except Exception as e:
-            return {'success': False, 'error': str(e)}
+            raise
 
     def serial_modhex(self):
         with self._open_device(TRANSPORT.OTP) as dev:
@@ -312,9 +302,7 @@ class Controller(object):
         except YkpersError as e:
             if e.errno == 3:
                 return {'success': False, 'error': 'write error'}
-            return {'success': False, 'error': str(e)}
-        except Exception as e:
-            return {'success': False, 'error': str(e)}
+            raise
 
     def program_challenge_response(self, slot, key, touch):
         try:
@@ -325,9 +313,7 @@ class Controller(object):
         except YkpersError as e:
             if e.errno == 3:
                 return {'success': False, 'error': 'write error'}
-            return {'success': False, 'error': str(e)}
-        except Exception as e:
-            return {'success': False, 'error': str(e)}
+            raise
 
     def program_static_password(self, slot, key, keyboard_layout):
         try:
@@ -339,9 +325,7 @@ class Controller(object):
         except YkpersError as e:
             if e.errno == 3:
                 return {'success': False, 'error': 'write error'}
-            return {'success': False, 'error': str(e)}
-        except Exception as e:
-            return {'success': False, 'error': str(e)}
+            raise
 
     def program_oath_hotp(self, slot, key, digits):
         try:
@@ -353,9 +337,7 @@ class Controller(object):
         except YkpersError as e:
             if e.errno == 3:
                 return {'success': False, 'error': 'write error'}
-            return {'success': False, 'error': str(e)}
-        except Exception as e:
-            return {'success': False, 'error': str(e)}
+            raise
 
     def fido_has_pin(self):
         try:
@@ -366,7 +348,7 @@ class Controller(object):
                     'error': None}
         except Exception as e:
             logger.error('Failed to read if PIN is set', exc_info=e)
-            return {'success': False, 'hasPin': None, 'error': str(e)}
+            raise
 
     def fido_pin_retries(self):
         try:
@@ -389,7 +371,7 @@ class Controller(object):
                     'error': 'PIN is blocked.'}
         except Exception as e:
             logger.error('Failed to read PIN retries', exc_info=e)
-            return {'success': False, 'retries': None, 'error': str(e)}
+            raise
 
     def fido_set_pin(self, new_pin):
         try:
@@ -400,10 +382,10 @@ class Controller(object):
             if e.code == CtapError.ERR.INVALID_LENGTH:
                 return {'success': False, 'error': 'too long'}
             logger.error('Failed to set PIN', exc_info=e)
-            return {'success': False, 'error': str(e)}
+            raise
         except Exception as e:
             logger.error('Failed to set PIN', exc_info=e)
-            return {'success': False, 'error': str(e)}
+            raise
 
     def fido_change_pin(self, current_pin, new_pin):
         try:
@@ -423,10 +405,10 @@ class Controller(object):
             if e.code == CtapError.ERR.PIN_BLOCKED:
                 return {'success': False, 'error': 'blocked'}
             logger.error('Failed to set PIN', exc_info=e)
-            return {'success': False, 'error': str(e)}
+            raise
         except Exception as e:
             logger.error('Failed to set PIN', exc_info=e)
-            return {'success': False, 'error': str(e)}
+            raise
 
     def fido_reset(self):
         try:
@@ -438,12 +420,7 @@ class Controller(object):
                 return {'success': False, 'error': 'not allowed'}
             if e.code == CtapError.ERR.ACTION_TIMEOUT:
                 return {'success': False, 'error': 'touch timeout'}
-            else:
-                logger.error('Reset throwed an exception', exc_info=e)
-                return {'success': False, 'error': str(e)}
-        except Exception as e:
-            logger.error('Reset throwed an exception', exc_info=e)
-            return {'success': False, 'error': str(e)}
+            raise
 
     def piv_reset(self):
         with self._open_piv() as controller:

--- a/ykman-gui/qml/Fido2ChangePinView.qml
+++ b/ykman-gui/qml/Fido2ChangePinView.qml
@@ -23,17 +23,17 @@ ChangePinView {
             if (resp.success) {
                 fido2SuccessPopup.open()
             } else {
-                if (resp.error === 'too long') {
+                if (resp.error_id === 'too long') {
                     fido2TooLongError.open()
-                } else if (resp.error === 'wrong pin') {
+                } else if (resp.error_id === 'wrong pin') {
                     clearCurrentPinInput()
                     fido2WrongPinError.open()
-                } else if (resp.error === 'currently blocked') {
+                } else if (resp.error_id === 'currently blocked') {
                     fido2CurrentlyBlockedError.open()
-                } else if (resp.error === 'blocked') {
+                } else if (resp.error_id === 'blocked') {
                     fido2BlockedError.open()
                 } else {
-                    fido2GeneralError.error = resp.error
+                    fido2GeneralError.error = resp.error_id
                     fido2GeneralError.open()
                 }
             }

--- a/ykman-gui/qml/Fido2ResetView.qml
+++ b/ykman-gui/qml/Fido2ResetView.qml
@@ -29,10 +29,10 @@ ColumnLayout {
                     if (resp.success) {
                         fido2SuccessPopup.open()
                     } else {
-                        if (resp.error === 'touch timeout') {
+                        if (resp.error_id === 'touch timeout') {
                             fido2ResetTouchError.open()
                         } else {
-                            fido2GeneralError.error = resp.error
+                            fido2GeneralError.error = resp.error_id
                             fido2GeneralError.open()
                         }
                     }

--- a/ykman-gui/qml/Fido2SetPinView.qml
+++ b/ykman-gui/qml/Fido2SetPinView.qml
@@ -26,10 +26,10 @@ ChangePinView {
             if (resp.success) {
                 fido2SuccessPopup.open()
             } else {
-                if (resp.error === 'too long') {
+                if (resp.error_id === 'too long') {
                     fido2TooLongError.open()
                 } else {
-                    fido2GeneralError.error = resp.error
+                    fido2GeneralError.error = resp.error_id
                     fido2GeneralError.open()
                 }
             }

--- a/ykman-gui/qml/Fido2View.qml
+++ b/ykman-gui/qml/Fido2View.qml
@@ -25,8 +25,8 @@ ColumnLayout {
                         if (resp.success) {
                             pinRetries = resp.retries
                         } else {
-                            console.log(resp.error)
-                            pinBlocked = (resp.error === 'PIN is blocked.')
+                            console.log(resp.error_id)
+                            pinBlocked = (resp.error_id === 'PIN is blocked.')
                         }
                         isBusy = false
                     })

--- a/ykman-gui/qml/InterfaceView.qml
+++ b/ykman-gui/qml/InterfaceView.qml
@@ -51,7 +51,7 @@ ColumnLayout {
                                     interfacesSuccessPopup.open()
                                     views.unlock()
                                 } else {
-                                    console.log(resp.error)
+                                    console.log(resp.error_id)
                                     views.unlock()
                                     errorLockCodePopup.open()
                                 }

--- a/ykman-gui/qml/OtpChalRespView.qml
+++ b/ykman-gui/qml/OtpChalRespView.qml
@@ -28,11 +28,11 @@ ColumnLayout {
                                              if (resp.success) {
                                                  views.otpSuccess()
                                              } else {
-                                                 if (resp.error === 'write error') {
+                                                 if (resp.error_id === 'write error') {
                                                      views.otpWriteError()
                                                  } else {
                                                      views.otpFailedToConfigureErrorPopup(
-                                                                 resp.error)
+                                                                 resp.error_id)
                                                  }
                                              }
                                          })

--- a/ykman-gui/qml/OtpOathHotpView.qml
+++ b/ykman-gui/qml/OtpOathHotpView.qml
@@ -20,11 +20,11 @@ ColumnLayout {
                                     if (resp.success) {
                                         views.otpSuccess()
                                     } else {
-                                        if (resp.error === 'write error') {
+                                        if (resp.error_id === 'write error') {
                                             views.otpWriteError()
                                         } else {
                                             views.otpFailedToConfigureErrorPopup(
-                                                        resp.error)
+                                                        resp.error_id)
                                         }
                                     }
                                 })

--- a/ykman-gui/qml/OtpStaticPasswordView.qml
+++ b/ykman-gui/qml/OtpStaticPasswordView.qml
@@ -22,11 +22,11 @@ ColumnLayout {
                                           if (resp.success) {
                                               views.otpSuccess()
                                           } else {
-                                              if (resp.error === 'write error') {
+                                              if (resp.error_id === 'write error') {
                                                   views.otpWriteError()
                                               } else {
                                                   views.otpFailedToConfigureErrorPopup(
-                                                              resp.error)
+                                                              resp.error_id)
                                               }
                                           }
                                       })

--- a/ykman-gui/qml/OtpView.qml
+++ b/ykman-gui/qml/OtpView.qml
@@ -22,11 +22,11 @@ ColumnLayout {
                 views.selectedSlot = 0
                 isBusy = false
             } else {
-                if (resp.error === 'timeout') {
+                if (resp.error_id === 'timeout') {
                     views.otpGeneralError(qsTr(
                                               "Failed to load OTP application"))
                 } else {
-                    views.otpGeneralError(resp.error)
+                    views.otpGeneralError(resp.error_id)
                 }
                 views.home()
             }

--- a/ykman-gui/qml/OtpView.qml
+++ b/ykman-gui/qml/OtpView.qml
@@ -62,10 +62,10 @@ ColumnLayout {
                 views.otpSuccess()
                 load()
             } else {
-                if (resp.error === 'write error') {
+                if (resp.error_id === 'write error') {
                     views.otpWriteError()
                 } else {
-                    views.otpGeneralError(resp.error)
+                    views.otpGeneralError(resp.error_id)
                 }
             }
         })

--- a/ykman-gui/qml/OtpView.qml
+++ b/ykman-gui/qml/OtpView.qml
@@ -47,10 +47,10 @@ ColumnLayout {
                 views.otpSuccess()
                 load()
             } else {
-                if (resp.error === 'write error') {
+                if (resp.error_id === 'write error') {
                     views.otpWriteError()
                 } else {
-                    views.otpFailedToConfigureErrorPopup(resp.error)
+                    views.otpFailedToConfigureErrorPopup(resp.error_id)
                 }
             }
         })

--- a/ykman-gui/qml/OtpYubiOtpView.qml
+++ b/ykman-gui/qml/OtpYubiOtpView.qml
@@ -41,11 +41,11 @@ ColumnLayout {
                                if (resp.success) {
                                    views.otpSuccess()
                                } else {
-                                   if (resp.error === 'write error') {
+                                   if (resp.error_id === 'write error') {
                                        views.otpWriteError()
                                    } else {
                                        views.otpFailedToConfigureErrorPopup(
-                                                   resp.error)
+                                                   resp.error_id)
                                    }
                                }
                            })

--- a/ykman-gui/qml/PivGeneralErrorPopup.qml
+++ b/ykman-gui/qml/PivGeneralErrorPopup.qml
@@ -22,12 +22,12 @@ InlinePopup {
                         constants.pivManagementKeyHexLength)
         case 'no_device':
             return qsTr('No YubiKey present.')
+        case 'open_device_failed':
+            return qsTr("Failed to open the application on the YubiKey.")
         case 'pin_blocked':
             return qsTr('PIN is blocked.')
         case 'pin_required':
             return qsTr("PIN is required.")
-        case 'piv_open_failed':
-            return qsTr("Failed to open the PIV application on the YubiKey.")
         case 'puk_blocked':
             return qsTr('PUK is blocked.')
         case 'wrong_mgm_key':


### PR DESCRIPTION
- Catch errors thrown in any public `Controller` method
- Make all functions return a dict with `success`, `error_id` or `error_message` (and optional extra properties)
- Introduce functions `success`, `failure` and `unknown_failure` that abstract the shared response format logic
- Change error ID `Multiple devices` to `multiple_devices` (currently unused)
- Change error ID `No device` to `no_device` (currently unused)
- Change error ID `Lock code not 16 bytes` to `lock_code_not_16_bytes` (currently unused)