### PR TITLE
static pw: support ` and \

### DIFF
--- a/ykman-gui/qml/OtpStaticPasswordView.qml
+++ b/ykman-gui/qml/OtpStaticPasswordView.qml
@@ -45,7 +45,7 @@ ColumnLayout {
 
     RegExpValidator {
         id: usLayoutValidator
-        regExp: /[ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!"#\$%&'\(\)\*\+,-\.\/:;<=>\?@\[\]\^_{}\|~]{1,38}$/
+        regExp: /[ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!"#\$%&'\\`\(\)\*\+,-\.\/:;<=>\?@\[\]\^_{}\|~]{1,38}$/
     }
 
     CustomContentColumn {


### PR DESCRIPTION
` and \ was not in regex validator, resulting in the generate button sometimes generating invalid passwords