### PR TITLE
piv: return failure if not key or cert

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -572,6 +572,10 @@ class Controller(object):
                 is_private_key = True
             except (ValueError, TypeError):
                 pass
+
+            if not (is_cert or is_private_key):
+                return failure('failed_parsing')
+
             with self._open_piv() as controller:
                 auth_failed = self._piv_ensure_authenticated(
                     controller, pin, mgm_key)

--- a/ykman-gui/qml/PivCertificateInfo.qml
+++ b/ykman-gui/qml/PivCertificateInfo.qml
@@ -64,12 +64,7 @@ ColumnLayout {
             if (resp.success) {
                 snackbarSuccess.show("Certificate was imported")
             } else {
-                if (resp.error === 'failed_parsing') {
-                    snackbarError.show(
-                                'Something went wrong with reading the file.')
-                } else {
-                    snackbarError.show(resp.error)
-                }
+                snackbarError.showResponseError(resp)
             }
             load()
         }

--- a/ykman-gui/qml/SnackBarError.qml
+++ b/ykman-gui/qml/SnackBarError.qml
@@ -44,7 +44,7 @@ SnackBar {
         case 'wrong_puk':
             return qsTr("Wrong PUK. Tries remaning: %1".arg(resp.tries_left))
         case 'failed_parsing':
-            return qsTr("Something went wrong with reading the file")
+            return qsTr("Failed to parse file")
         }
     }
 

--- a/ykman-gui/qml/SnackBarError.qml
+++ b/ykman-gui/qml/SnackBarError.qml
@@ -43,6 +43,8 @@ SnackBar {
             return qsTr('Wrong PIN. Tries remaning: %1'.arg(resp.tries_left))
         case 'wrong_puk':
             return qsTr("Wrong PUK. Tries remaning: %1".arg(resp.tries_left))
+        case 'failed_parsing':
+            return qsTr("Something went wrong with reading the file")
         }
     }
 


### PR DESCRIPTION
this fixes a bug where importing a cert with wrong password fails silently