### PR TITLE
piv: always require PIN for import

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -591,6 +591,11 @@ class Controller(object):
                     else:
                         cert_to_import = certs[0]
                     try:
+                        # PIN is needed because import will try to
+                        # use the private key for verification
+                        pin_failed = self._piv_verify_pin(controller, pin)
+                        if pin_failed:
+                            return pin_failed
                         controller.import_certificate(
                             SLOT[slot], cert_to_import, verify=True)
                     except KeypairMismatch:

--- a/ykman-gui/qml/PivCertificateInfo.qml
+++ b/ykman-gui/qml/PivCertificateInfo.qml
@@ -71,11 +71,15 @@ ColumnLayout {
 
         function _tryImport(password) {
             views.pivGetPinOrManagementKey(function (pin) {
+                // We got the pin, nothing more needed
                 yubiKey.pivImportFile(slot.id, fileUrl, password, pin, null,
                                       handleResponse)
             }, function (managementKey) {
-                yubiKey.pivImportFile(slot.id, fileUrl, password, null,
-                                      managementKey, handleResponse)
+                // We got the mgm key, need pin as well for verification
+                pivPinPopup.getInputAndThen(function (pin) {
+                    yubiKey.pivImportFile(slot.id, fileUrl, password, pin,
+                                          managementKey, handleResponse)
+                })
             })
         }
 


### PR DESCRIPTION
Always require PIN for import since the private key is used for verifying that the private key and certificate matches. Currently import from file only works when the management key is protected by PIN, this fixes that.