### PR TITLE
piv: accept upper and lower case hex for management key

### DIFF
--- a/ykman-gui/qml/PivManagementKeyTextField.qml
+++ b/ykman-gui/qml/PivManagementKeyTextField.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls.Material 2.2
 CustomTextField {
     maximumLength: constants.pivManagementKeyHexLength
     validator: RegExpValidator {
-        regExp: /[0-9a-f]*/
+        regExp: /[0-9a-fA-F]*/
     }
     toolTipText: qsTr("Management key must be exactly 48 hexadecimal digits.")
 }


### PR DESCRIPTION
Just for convenience, also accept upper case characters for the management hex key