### PR TITLE
piv: fix a problem with importing a private key

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -565,7 +565,8 @@ class Controller(object):
             data = file.read()
             try:
                 certs = parse_certificates(data, password)
-                is_cert = True
+                if len(certs) > 0:
+                    is_cert = True
             except (ValueError, TypeError):
                 pass
             try:


### PR DESCRIPTION
parse_certificates() does not throw an exception when you give it a private
key to parse. It will simply return an empty list. See issue #171 