### PR TITLE
fix static pw generation

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -270,8 +270,9 @@ class Controller(object):
             return modhex_encode(b'\xff\x00' + struct.pack(b'>I', dev.serial))
 
     def generate_static_pw(self, keyboard_layout):
-        return generate_static_pw(
-            38, KEYBOARD_LAYOUT[keyboard_layout]).decode('utf-8')
+        return success({
+            'password': generate_static_pw(38, KEYBOARD_LAYOUT[keyboard_layout])
+        })
 
     def random_uid(self):
         return b2a_hex(os.urandom(6)).decode('ascii')

--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -271,7 +271,8 @@ class Controller(object):
 
     def generate_static_pw(self, keyboard_layout):
         return success({
-            'password': generate_static_pw(38, KEYBOARD_LAYOUT[keyboard_layout])
+            'password': generate_static_pw(
+                38, KEYBOARD_LAYOUT[keyboard_layout])
         })
 
     def random_uid(self):

--- a/ykman-gui/qml/OtpStaticPasswordView.qml
+++ b/ykman-gui/qml/OtpStaticPasswordView.qml
@@ -35,8 +35,12 @@ ColumnLayout {
     }
 
     function generatePassword() {
-        yubiKey.generateStaticPw(keyboardLayout, function (res) {
-            passwordInput.text = res
+        yubiKey.generateStaticPw(keyboardLayout, function (resp) {
+            if (resp.success) {
+                passwordInput.text = resp.password
+            } else {
+                snackbarError.showResponseError(resp)
+            }
         })
     }
 


### PR DESCRIPTION
fixes #181 and parts of #178 

the bug was introduced because `ykman.util.generate_static_pw` now generates a string and the GUI was not updated to reflect that.