### PR TITLE
piv: add checkbox to use default management key in popup

### DIFF
--- a/ykman-gui/qml/PivManagementKeyPopup.qml
+++ b/ykman-gui/qml/PivManagementKeyPopup.qml
@@ -1,8 +1,18 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.2
+import QtQuick.Controls.Material 2.2
 
 AuthenticationPopup {
+
+    function toggleUseDefaultCurrentManagementKey() {
+        if (useDefaultChkBox.checked) {
+            keyInput.text = constants.pivDefaultManagementKey
+        } else {
+            keyInput.clear()
+        }
+    }
+
     ColumnLayout {
         width: parent.width
         spacing: 10
@@ -26,7 +36,20 @@ AuthenticationPopup {
                 background.width: width
                 Layout.fillWidth: true
                 onAccepted: accept()
+                enabled: !useDefaultChkBox.checked
+            }
+
+            CheckBox {
+                id: useDefaultChkBox
+                text: qsTr("Use default")
+                checked: false
+                onCheckedChanged: toggleUseDefaultCurrentManagementKey()
+                font.pixelSize: constants.h3
+                Material.foreground: yubicoBlue
             }
         }
+        onVisibleChanged: if (visible) {
+                            useDefaultChkBox.checked = false
+                          }
     }
 }

--- a/ykman-gui/qml/PivSetManagementKeyView.qml
+++ b/ykman-gui/qml/PivSetManagementKeyView.qml
@@ -33,10 +33,6 @@ ColumnLayout {
         })
     }
 
-    function inputDefaultManagementKey() {
-        currentManagementKey.text = constants.pivDefaultManagementKey
-    }
-
     function toggleUseDefaultCurrentManagementKey() {
         if (useDefaultCurrentManagementKeyCheckbox.checked) {
             currentManagementKey.text = constants.pivDefaultManagementKey
@@ -118,7 +114,6 @@ ColumnLayout {
                     Material.foreground: yubicoBlue
                     visible: hasCurrentManagementKeyInput
                 }
-
                 Label {
                     text: qsTr("New Management Key")
                     font.pixelSize: constants.h3


### PR DESCRIPTION
- Makes it easier for users when testing different setups in PIV, the default management key is long and hard to remember
- We have this in the CLI ("Press blank for default key")

Considerations:
- It might make it easier to use default management key in production by mistake