### PR TITLE
Run qsTr on literals only

### DIFF
--- a/ykman-gui/qml/ConfirmationPopup.qml
+++ b/ykman-gui/qml/ConfirmationPopup.qml
@@ -10,8 +10,8 @@ InlinePopup {
     focus: true
 
     function show(heading, message, cb) {
-        confirmationHeading.text = qsTr(heading)
-        confirmationLbl.text = qsTr(message)
+        confirmationHeading.text = heading
+        confirmationLbl.text = message
         acceptCallback = cb
         open()
     }

--- a/ykman-gui/qml/ContentStack.qml
+++ b/ykman-gui/qml/ContentStack.qml
@@ -162,9 +162,9 @@ StackView {
 
     function otpConfirmOverwrite(callback) {
         confirmationPopup.show(
-                    "Overwrite?", "%1 is already configured.".arg(
-                        SlotUtils.slotNameCapitalized(views.selectedSlot))
-                    + " Do you want to overwrite the existing configuration?",
+                    qsTr("Overwrite?"), qsTr(
+                        "%1 is already configured. Do you want to overwrite the existing configuration?").arg(
+                        SlotUtils.slotNameCapitalized(views.selectedSlot)),
                     callback)
     }
 

--- a/ykman-gui/qml/Fido2ChangePinView.qml
+++ b/ykman-gui/qml/Fido2ChangePinView.qml
@@ -17,7 +17,7 @@ ChangePinView {
         yubiKey.fidoChangePin(currentPin, newPin, function (resp) {
             if (resp.success) {
                 views.fido2()
-                snackbarSuccess.show("Changed FIDO2 PIN")
+                snackbarSuccess.show(qsTr("Changed FIDO2 PIN"))
             } else {
                 if (resp.error_id === 'too long') {
                     snackbarError.show(qsTr("Too long PIN"))

--- a/ykman-gui/qml/Fido2SetPinView.qml
+++ b/ykman-gui/qml/Fido2SetPinView.qml
@@ -20,7 +20,7 @@ ChangePinView {
         yubiKey.fidoSetPin(newPin, function (resp) {
             if (resp.success) {
                 views.fido2()
-                snackbarSuccess.show("FIDO2 PIN was set")
+                snackbarSuccess.show(qsTr("FIDO2 PIN was set"))
             } else {
                 if (resp.error_id === 'too long') {
                     snackbarError.show(qsTr("Too long PIN"))

--- a/ykman-gui/qml/InterfaceView.qml
+++ b/ykman-gui/qml/InterfaceView.qml
@@ -49,7 +49,7 @@ ColumnLayout {
                                     views.home()
                                     views.unlock()
                                     snackbarSuccess.show(
-                                                "Configured interfaces")
+                                                qsTr("Configured interfaces"))
                                 } else {
                                     views.unlock()
                                     snackbarError.showResponseError(resp)

--- a/ykman-gui/qml/OtpChalRespView.qml
+++ b/ykman-gui/qml/OtpChalRespView.qml
@@ -28,7 +28,7 @@ ColumnLayout {
                                              if (resp.success) {
                                                  views.otp()
                                                  snackbarSuccess.show(
-                                                             "Configured Challenge-Response credential")
+                                                             qsTr("Configured Challenge-Response credential"))
                                              } else {
                                                  if (resp.error_id === 'write error') {
                                                      views.otpWriteError()

--- a/ykman-gui/qml/OtpOathHotpView.qml
+++ b/ykman-gui/qml/OtpOathHotpView.qml
@@ -20,7 +20,7 @@ ColumnLayout {
                                     if (resp.success) {
                                         views.otp()
                                         snackbarSuccess.show(
-                                                    "Configured OATH-HOTP credential")
+                                                    qsTr("Configured OATH-HOTP credential"))
                                     } else {
                                         if (resp.error_id === 'write error') {
                                             views.otpWriteError()

--- a/ykman-gui/qml/OtpView.qml
+++ b/ykman-gui/qml/OtpView.qml
@@ -43,8 +43,8 @@ ColumnLayout {
 
     function confirmDelete() {
         confirmationPopup.show(
-                    "Delete slot?",
-                    "Do you want to delete the content of %1? This permanently deletes the configuration.".arg(
+                    qsTr("Delete slot?"), qsTr(
+                        "Do you want to delete the content of %1? This permanently deletes the configuration.").arg(
                         SlotUtils.slotNameCapitalized(views.selectedSlot)),
                     deleteSelectedSlot)
     }
@@ -54,7 +54,7 @@ ColumnLayout {
         yubiKey.eraseSlot(views.selectedSlot, function (resp) {
             if (resp.success) {
                 load()
-                snackbarSuccess.show("Configuration deleted")
+                snackbarSuccess.show(qsTr("Configuration deleted"))
             } else {
                 if (resp.error_id === 'write error') {
                     views.otpWriteError()
@@ -70,7 +70,8 @@ ColumnLayout {
             if (resp.success) {
 
                 load()
-                snackbarSuccess.show("Configurations swapped between slots")
+                snackbarSuccess.show(
+                            qsTr("Configurations swapped between slots"))
             } else {
                 if (resp.error_id === 'write error') {
                     snackbarError.show(

--- a/ykman-gui/qml/OtpYubiOtpView.qml
+++ b/ykman-gui/qml/OtpYubiOtpView.qml
@@ -41,7 +41,7 @@ ColumnLayout {
                                if (resp.success) {
                                    views.otp()
                                    snackbarSuccess.show(
-                                               "Configured Yubico OTP credential")
+                                               qsTr("Configured Yubico OTP credential"))
                                } else {
                                    if (resp.error_id === 'write error') {
                                        views.otpWriteError()

--- a/ykman-gui/qml/PivCertificateInfo.qml
+++ b/ykman-gui/qml/PivCertificateInfo.qml
@@ -25,15 +25,15 @@ ColumnLayout {
 
     function deleteCertificate() {
         confirmationPopup.show(
-                    "Delete certificate?",
-                    "This will delete the certificate stored in slot %1, and cannot be undone. Note that the private key is not deleted.".arg(
+                    qsTr("Delete certificate?"), qsTr(
+                        "This will delete the certificate stored in slot %1, and cannot be undone. Note that the private key is not deleted.").arg(
                         slot.hex), function () {
                             function _finish(pin, managementKey) {
                                 yubiKey.pivDeleteCertificate(slot.id, pin,
                                                              managementKey,
                                                              function (resp) {
                                                                  if (resp.success) {
-                                                                     snackbarSuccess.show("Certificate was deleted")
+                                                                     snackbarSuccess.show(qsTr("Certificate was deleted"))
                                                                  } else {
                                                                      snackbarError.showResponseError(resp)
                                                                  }
@@ -51,7 +51,7 @@ ColumnLayout {
     function exportCertificate(fileUrl) {
         yubiKey.pivExportCertificate(slot.id, fileUrl, function (resp) {
             if (resp.success) {
-                snackbarSuccess.show("Certificate was exported")
+                snackbarSuccess.show(qsTr("Certificate was exported"))
             } else {
                 snackbarError.showResponseError(resp)
             }

--- a/ykman-gui/qml/PivChangePinView.qml
+++ b/ykman-gui/qml/PivChangePinView.qml
@@ -15,7 +15,7 @@ ChangePinView {
         yubiKey.pivChangePin(currentPin, newPin, function (resp) {
             if (resp.success) {
                 views.pop()
-                snackbarSuccess.show("Changed PIN")
+                snackbarSuccess.show(qsTr("Changed PIN"))
             } else {
                 snackbarError.showResponseError(resp, {
                                                wrong_pin: qsTr("Wrong current PIN. Tries remaining: %1").arg(

--- a/ykman-gui/qml/PivChangePukView.qml
+++ b/ykman-gui/qml/PivChangePukView.qml
@@ -17,7 +17,7 @@ ChangePinView {
         yubiKey.pivChangePuk(currentPin, newPin, function (resp) {
             if (resp.success) {
                 views.pop()
-                snackbarSuccess.show("Changed PUK")
+                snackbarSuccess.show(qsTr("Changed PUK"))
             } else {
                 snackbarError.showResponseError(resp, {
                                                     wrong_puk: qsTr("Wrong current PUK. Tries remaining: %1").arg(

--- a/ykman-gui/qml/PivGenerateCertificateWizard.qml
+++ b/ykman-gui/qml/PivGenerateCertificateWizard.qml
@@ -31,7 +31,7 @@ ColumnLayout {
                                          isBusy = false
                                          if (resp.success) {
                                              snackbarSuccess.show(
-                                                         "Certificate Signing Request (CSR) generated")
+                                                         qsTr("Certificate Signing Request (CSR) generated"))
                                          } else {
                                              snackbarError.showResponseError(
                                                          resp)
@@ -75,7 +75,7 @@ ColumnLayout {
                                                            isBusy = false
                                                            views.pop()
                                                            snackbarSuccess.show(
-                                                                       "Self-signed certificate generated")
+                                                                       qsTr("Self-signed certificate generated"))
                                                        } else {
                                                            deleteCertificate(
                                                                        pin,
@@ -95,11 +95,11 @@ ColumnLayout {
                 selectCsrOutputDialog.open()
             }
         } else {
-            var firstMessageTemplate = selfSign ? "This will overwrite the key and certificate in the %1 (%2) slot." : "This will overwrite the key and delete the certificate in the %1 (%2) slot."
-            confirmationPopup.show("Overwrite?", firstMessageTemplate.arg(
-                                       slot.name).arg(slot.hex) + "
+            var firstMessageTemplate = selfSign ? qsTr("This will overwrite the key and certificate in the %1 (%2) slot.") : qsTr("This will overwrite the key and delete the certificate in the %1 (%2) slot.")
+            confirmationPopup.show(qsTr("Overwrite?"), firstMessageTemplate.arg(
+                                       slot.name).arg(slot.hex) + qsTr("
 
-Do you want to continue?", function () {
+Do you want to continue?"), function () {
     finish(true)
 })
         }

--- a/ykman-gui/qml/PivSetManagementKeyView.qml
+++ b/ykman-gui/qml/PivSetManagementKeyView.qml
@@ -55,7 +55,7 @@ ColumnLayout {
 
                 if (resp.success) {
                     views.pivPinManagement()
-                    snackbarSuccess.show("Changed the Management Key")
+                    snackbarSuccess.show(qsTr("Changed the Management Key"))
                 } else {
                     snackbarError.showResponseError(resp, {
                                                         mgm_key_bad_format: qsTr("Current management key must be exactly %1 hexadecimal characters").arg(constants.pivManagementKeyHexLength),

--- a/ykman-gui/qml/PivSetupForMacOsView.qml
+++ b/ykman-gui/qml/PivSetupForMacOsView.qml
@@ -56,7 +56,7 @@ ColumnLayout {
                         if (resp.success) {
                             views.pop()
                             snackbarSuccess.show(
-                                        "Remove and re-insert your YubiKey to start the macOS pairing setup.")
+                                        qsTr("Remove and re-insert your YubiKey to start the macOS pairing setup."))
                         } else {
                             snackbarError.showResponseError(resp)
                         }
@@ -74,8 +74,8 @@ ColumnLayout {
             _prompt_for_pin_and_key()
         } else {
             confirmationPopup.show(
-                        "Overwrite?",
-                        "This will overwrite any existing key and certificate in slot 9a and 9d. This action cannot be undone! Are you sure you want to continue?",
+                        qsTr("Overwrite?"), qsTr(
+                            "This will overwrite any existing key and certificate in slot 9a and 9d. This action cannot be undone! Are you sure you want to continue?"),
                         function () {
                             setupForMacOs(true)
                         })

--- a/ykman-gui/qml/PivUnblockPinView.qml
+++ b/ykman-gui/qml/PivUnblockPinView.qml
@@ -19,7 +19,7 @@ ChangePinView {
         yubiKey.pivUnblockPin(currentPin, newPin, function (resp) {
             if (resp.success) {
                 views.pop()
-                snackbarSuccess.show("PUK was unblocked")
+                snackbarSuccess.show(qsTr("PUK was unblocked"))
             } else {
                 snackbarError.showResponseError(resp)
 

--- a/ykman-gui/qml/PivView.qml
+++ b/ykman-gui/qml/PivView.qml
@@ -40,16 +40,16 @@ ColumnLayout {
 
     function resetPiv() {
         confirmationPopup.show(
-                    "Reset PIV?",
-                    "This will delete all PIV data, and restore all PINs to the default values.
+                    qsTr("Reset PIV?"), qsTr(
+                        "This will delete all PIV data, and restore all PINs to the default values.
 
-This action cannot be undone!", function () {
+This action cannot be undone!"), function () {
     isBusy = true
     yubiKey.pivReset(function (resp) {
         isBusy = false
         if (resp.success) {
             load()
-            snackbarSuccess.show("PIV application has been reset")
+            snackbarSuccess.show(qsTr("PIV application has been reset"))
         } else {
             snackbarError.showResponseError(resp)
         }


### PR DESCRIPTION
As evidenced by running `lupdate yubikey-manager-qt.pro -ts sv.ts`, the `qsTr` function is meant to be run on literals rather than variable expressions. Before this change, the above command finds 294 strings to translate; after, it finds 326.