### PR TITLE
help and info icons should now be visible in a vm

### DIFF
--- a/ykman-gui/qml/Header.qml
+++ b/ykman-gui/qml/Header.qml
@@ -33,21 +33,33 @@ ColumnLayout {
                 color: yubicoBlue
                 font.pixelSize: constants.h4
             }
-            CustomButton {
+            ToolButton {
+                id: helpBtn
                 flat: true
                 text: qsTr("Help")
                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                iconSource: "../images/help.svg"
-                toolTipText: qsTr("Visit Yubico Support in your web browser")
+                icon.source: "../images/help.svg"
+                ToolTip {
+                    text: qsTr("Visit Yubico Support in your web browser")
+                    delay: 1000
+                    parent: helpBtn
+                    visible: parent.hovered
+                }
                 onClicked: Qt.openUrlExternally("https://www.yubico.com/kb")
                 font.pixelSize: constants.h4
             }
-            CustomButton {
+            ToolButton {
+                id: infoBtn
                 flat: true
                 text: qsTr("About")
                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                iconSource: "../images/info.svg"
-                toolTipText: qsTr("About YubiKey Manager")
+                icon.source: "../images/info.svg"
+                ToolTip {
+                    text: qsTr("About YubiKey Manager")
+                    delay: 1000
+                    parent: infoBtn
+                    visible: parent.hovered
+                }
                 onClicked: aboutPage.open()
                 font.pixelSize: constants.h4
             }


### PR DESCRIPTION
In a VM you used to see this:
![image](https://user-images.githubusercontent.com/5614478/70313807-99637280-1816-11ea-8113-fb26eb701a3f.png)
With this fix, it should look like this:
![image](https://user-images.githubusercontent.com/5614478/70313918-c3b53000-1816-11ea-9605-12f623cd1dac.png)

Tested on Windows 10 in Virtualbox.