### PR TITLE
Use Swig preinstalled on GitHub Actions

### DIFF
--- a/.github/workflows/windows-x64.yml
+++ b/.github/workflows/windows-x64.yml
@@ -38,7 +38,7 @@ jobs:
         shell: powershell
 
       - name: Install swig
-        run: choco install swig --version=4.0.1
+        run: choco install swig
 
       - name: Install jom
         run: |

--- a/.github/workflows/windows-x86.yml
+++ b/.github/workflows/windows-x86.yml
@@ -38,7 +38,7 @@ jobs:
         shell: powershell
 
       - name: Install swig
-        run: choco install swig --version=4.0.1
+        run: choco install swig
 
       - name: Install jom
         run: |


### PR DESCRIPTION
Builds are currently failing because a newer version of Swig is already installed:

```
Run choco install swig --version=4.0.1
Chocolatey v0.10.15
Installing the following packages:
swig
By installing you accept licenses for the packages.
A newer version of swig (v4.0.2.04082020) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions, or use side by side to allow multiple versions.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - swig - A newer version of swig (v4.0.2.04082020) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions, or use side by side to allow multiple versions.
Error: Process completed with exit code 1.
```

GitHub Actions added Swig to the preinstalled software in July: https://github.com/actions/virtual-environments/commit/659b9d878ccce5152198e2ff8aeae3663d39b7f0