### PR TITLE
added metainfo file

### DIFF
--- a/debian/yubikey-manager-qt.install
+++ b/debian/yubikey-manager-qt.install
@@ -1,2 +1,3 @@
 resources/icons/ykman.png usr/share/pixmaps
+resources/com.yubico.yubikey_manager.metainfo.xml usr/share/metainfo/
 resources/ykman-gui.desktop usr/share/applications

--- a/resources/com.yubico.yubikey_manager.metainfo.xml
+++ b/resources/com.yubico.yubikey_manager.metainfo.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.yubico.yubikey_manager</id>
+  
+  <name>Yubikey manager</name>
+  <summary>  Cross-platform application for configuring any YubiKey over all USB interfaces. </summary>
+  
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>BSD-2-Clause</project_license>
+  <content_rating type="oars-1.1" />
+  <url type="homepage">https://developers.yubico.com/yubikey-manager-qt/</url>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </recommends>
+  
+  <description>
+    <p>
+      Yubikey manager provides an easy way to perform the most common configuration tasks on a YubiKey.
+    </p>
+    <p>
+      The current version can:
+    </p>
+    <p>
+      - Display the serial number and firmware version of a YubiKey
+    </p>
+    <p>
+      - Configure a FIDO2 PIN
+    </p>
+    <p>
+      - Reset the FIDO Applications
+    </p>
+    <p>
+      - Configure the OTP Application. A YubiKey have two slots (Short Touch and Long Touch), which may both be configured for different functionality.  This tool can configure a Yubico OTP credential, a static password, a challenge-response credential or an OATH HOTP credential in both of these slots.
+    </p>
+    <p>
+      - Manage certificates and PINs for the PIV Application
+    </p>
+    <p>
+      - Swap the credentials between two configured slots
+    </p>
+    <p>
+      - Enable and disable USB and NFC interfaces
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">com.yubico.yubikey_manager.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <caption>yubikey manager qt</caption>
+      <image>https://developers.yubico.com/yubikey-manager-qt/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+        <release version="yubikey-manager-qt-1.2.3" date="2021-04-14">
+            <description>
+            	<p>Version 1.2.3 (released 2021-04-13) </p>
+              <ul>
+                <li>Improved error handling when using Security Key Series devices.</li>
+                <li>PIV: Fix generation of certificate in slot 9c.</li>
+                <li>MacOS: Use correct path when importing files.</li>
+              </ul>
+            </description>
+        </release>
+    </releases>
+</component>


### PR DESCRIPTION
Adding a metainfo file allows app stores such as the Gnome store or KDE's discover to show screenshots and long description to its users. it makes sense to have this in the upstream repository. 