### PR TITLE
port build process to python3

### DIFF
--- a/build_qrc.py
+++ b/build_qrc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/ykman-cli/ykman-cli.pro
+++ b/ykman-cli/ykman-cli.pro
@@ -6,7 +6,7 @@ CONFIG -= app_bundle
 TEMPLATE = app
 SOURCES += main.cpp
 
-buildqrc.commands = python ../build_qrc.py ${QMAKE_FILE_IN}
+buildqrc.commands = python3 ../build_qrc.py ${QMAKE_FILE_IN}
 buildqrc.input = QRC_JSON
 buildqrc.output = ${QMAKE_FILE_IN_BASE}.qrc
 buildqrc.variable_out = RESOURCES
@@ -14,7 +14,7 @@ QMAKE_STRIPFLAGS_LIB  += --strip-unneeded
 QMAKE_EXTRA_COMPILERS += buildqrc
 QRC_JSON = resources.json
 # Generate first time
-system(python ../build_qrc.py resources.json)
+system(python3 ../build_qrc.py resources.json)
 
 # Install python dependencies with pip for win and mac
 mac|win32 {

--- a/ykman-gui/ykman-gui.pro
+++ b/ykman-gui/ykman-gui.pro
@@ -14,7 +14,7 @@ DEFINES += APP_VERSION=\\\"1.2.4\\\"
 
 message(Version of this build: $$VERSION)
 
-buildqrc.commands = python ../build_qrc.py ${QMAKE_FILE_IN}
+buildqrc.commands = python3 ../build_qrc.py ${QMAKE_FILE_IN}
 buildqrc.input = QRC_JSON
 buildqrc.output = ${QMAKE_FILE_IN_BASE}.qrc
 buildqrc.variable_out = RESOURCES
@@ -25,7 +25,7 @@ QMAKE_EXTRA_COMPILERS += buildqrc
 QRC_JSON = resources.json
 
 # Generate first time
-system(python ../build_qrc.py resources.json)
+system(python3 ../build_qrc.py resources.json)
 
 # Install python dependencies with pip on mac and win
 win32|macx {


### PR DESCRIPTION
python (2) is going away. This is what's needed to make yubikey-manager-qt build on Debian (bookworm/unstable) using python3. There's probably more work to do in the github workflows and resources/linux/AppRun