### PR TITLE
Add keyboard layout option to `OtpStaticPasswordView.qml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 - repo: local
   hooks:
   - id: qmllint


### PR DESCRIPTION
https://github.com/Yubico/yubikey-manager-qt/assets/99439005/767e2a94-00e6-43dd-910f-1fc21590dc4c

Currently this program only allows the user to set the OTP static password using the "MODHEX" or "US" scancodes, however many people<sup>[\[1\]][1]</sup><sup>[\[2\]][2]</sup><sup>[\[3\]][3]</sup> including me would like to use other keyboard layouts for this.

The regular expressions used for validation were generated using the [scancodes from `yubikey-manager`](https://github.com/Yubico/yubikey-manager/tree/51a7ae438c923189788a1e31d3de18d452131942/ykman/scancodes), I made a short Python script for this: https://github.com/piotrpdev/yubikey-scancode-regexp-gen. This way it should be easy to update the regular expressions in the future (I also released the code under [The Unlicense](https://choosealicense.com/licenses/unlicense/)).

[1]: https://forum.yubico.com/viewtopic9fa9.html?p=8416
[2]: https://forum.yubico.com/viewtopic1ee6.html?p=10078
[3]: https://forum.yubico.com/viewtopic4dd2.html?p=4674