### PR TITLE
Allow disabling the trailing Enter when setting a static password

### DIFF
--- a/ykman-gui/py/yubikey.py
+++ b/ykman-gui/py/yubikey.py
@@ -441,13 +441,14 @@ class Controller(object):
                 return failure("write error")
         return success()
 
-    def program_static_password(self, slot, key, keyboard_layout):
+    def program_static_password(self, slot, key, enter, keyboard_layout):
         with self._open_device([OtpConnection]) as conn:
             session = YubiOtpSession(conn)
             scan_codes = encode(key, KEYBOARD_LAYOUT[keyboard_layout])
+            slot_config = StaticPasswordSlotConfiguration(scan_codes).append_cr(enter)
 
             try:
-                session.put_configuration(slot, StaticPasswordSlotConfiguration(scan_codes))
+                session.put_configuration(slot, slot_config)
             except CommandError as e:
                 logger.debug("Failed to program static password", exc_info=e)
                 return failure("write error")

--- a/ykman-gui/qml/OtpStaticPasswordView.qml
+++ b/ykman-gui/qml/OtpStaticPasswordView.qml
@@ -7,6 +7,7 @@ import QtQuick.Controls.Material 2.2
 ColumnLayout {
 
     property string keyboardLayout: allowNonModhex.checked ? 'US' : 'MODHEX'
+    property bool enter: appendCR.checked
 
     function finish() {
         if (views.selectedSlotConfigured()) {
@@ -17,7 +18,7 @@ ColumnLayout {
     }
 
     function programStaticPassword() {
-        yubiKey.programStaticPassword(views.selectedSlot, passwordInput.text,
+        yubiKey.programStaticPassword(views.selectedSlot, passwordInput.text, enter,
                                       keyboardLayout, function (resp) {
                                           if (resp.success) {
                                               views.otp()
@@ -80,6 +81,7 @@ ColumnLayout {
                 toolTipText: qsTr("Generate a random password")
             }
         }
+
         CheckBox {
             id: allowNonModhex
             text: qsTr("Allow any character")
@@ -89,6 +91,17 @@ ColumnLayout {
             ToolTip.delay: 1000
             ToolTip.visible: hovered
             ToolTip.text: qsTr("By default only modhex characters are allowed, enable this option to allow any (US Layout) characters")
+        }
+
+        CheckBox {
+            id: appendCR
+            text: qsTr("Append a CR to the password")
+            checked: true
+            font.pixelSize: constants.h3
+            Material.foreground: yubicoBlue
+            ToolTip.delay: 1000
+            ToolTip.visible: hovered
+            ToolTip.text: qsTr("After entering the password, simulate pressing Enter or Return")
         }
 
         ButtonsBar {

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -331,9 +331,9 @@ Python {
                [slot, key, touch], cb)
     }
 
-    function programStaticPassword(slot, password, keyboardLayout, cb) {
+    function programStaticPassword(slot, password, enter, keyboardLayout, cb) {
         doCall('yubikey.controller.program_static_password',
-               [slot, password, keyboardLayout], cb)
+               [slot, password, enter, keyboardLayout], cb)
     }
 
     function programOathHotp(slot, key, digits, cb) {


### PR DESCRIPTION
Resolve issue #301: Enable --no-enter during setting static OTP