### PR TITLE
fix typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -70,7 +70,7 @@
  ** Add support for Security Key NFC
  ** Add support for managing PIV Application
  ** Bugfix: OATH-HOTP credentials was always configured with 6 digits
- ** UI: Replace Succes-popups with Snackbar-messages
+ ** UI: Replace Success-popups with Snackbar-messages
  ** UX: Drop confirmation prompt for OTP Swap Slots
 
 * Version 1.0.1 (released 2018-10-10)

--- a/ykman-cli/ykman-cli.pro
+++ b/ykman-cli/ykman-cli.pro
@@ -31,7 +31,7 @@ macx {
     pip.commands = pip3 install -r ../requirements.txt --target pymodules
 }
 
-# On mac, embedd a Info.plist file in the binary, needed for codesign
+# On mac, embed a Info.plist file in the binary, needed for codesign
 macx{
     QMAKE_LFLAGS += -sectcreate __TEXT __info_plist $$shell_quote(../resources/mac/Info.plist.cli)
 }

--- a/ykman-gui/qml/PivSetupForMacOsView.qml
+++ b/ykman-gui/qml/PivSetupForMacOsView.qml
@@ -8,7 +8,7 @@ ColumnLayout {
 
     readonly property string authenticationName: 'Yubico PIV Authentication'
     readonly property string encryptionName: 'Yubico PIV Encryption'
-    readonly property string algoritm: 'ECCP256'
+    readonly property string algorithm: 'ECCP256'
     property string expirationDate: Utils.formatDate(
                                         getExpirationDateIn30years())
     property bool isBusy
@@ -40,7 +40,7 @@ ColumnLayout {
             function _generateCertificate(slot, cb) {
                 yubiKey.pivGenerateCertificate({
                                                    slotName: slot,
-                                                   algorithm: algoritm,
+                                                   algorithm: algorithm,
                                                    commonName: authenticationName,
                                                    expirationDate: expirationDate,
                                                    selfSign: true,

--- a/ykman-gui/qml/YubiKey.qml
+++ b/ykman-gui/qml/YubiKey.qml
@@ -260,7 +260,7 @@ Python {
      * and then itself when `refresh` is done.
      *
      * The arguments and `this` context of the call to the `callback` are
-     * preseved.
+     * preserved.
      *
      * @param callback a function
      *


### PR DESCRIPTION
If the `.github/workflows` directory file should be changed let me know.

```
$ grep -nr intall yubikey-manager-qt
yubikey-manager-qt/.github/workflows/macOS.yml:61:          # Re-intall after, because it's needed for wget.
$ 
```

I presume the changes to `PivSetupForMacOsView.qml` are correct.